### PR TITLE
Add xml metadata to saml auth

### DIFF
--- a/akeyless/resource_auth_method.go
+++ b/akeyless/resource_auth_method.go
@@ -67,8 +67,13 @@ func resourceAuthMethod() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"idp_metadata_url": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 							Description: "IDP metadata url",
+						},
+						"idp_metadata_xml_data": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "IDP metadata xml data",
 						},
 						"unique_identifier": {
 							Type:        schema.TypeString,
@@ -435,12 +440,14 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 	if samlAuthMethod != nil && len(samlAuthMethod) == 1 {
 		saml := samlAuthMethod[0].(map[string]interface{})
 		idpMetadataUrl := saml["idp_metadata_url"].(string)
+        idpMetadataXmlData := saml["idp_metadata_xml_data"].(string)
 		uniqueIdentifier := saml["unique_identifier"].(string)
 		body := akeyless.CreateAuthMethodSAML{
 			Name:             path,
 			BoundIps:         &boundIpsList,
 			AccessExpires:    &accessExpires,
 			IdpMetadataUrl:   akeyless.PtrString(idpMetadataUrl),
+            IdpMetadataXmlData:   akeyless.PtrString(idpMetadataXmlData),
 			UniqueIdentifier: uniqueIdentifier,
 			Token:            &token,
 		}

--- a/akeyless/resource_auth_method_saml.go
+++ b/akeyless/resource_auth_method_saml.go
@@ -64,7 +64,7 @@ func resourceAuthMethodSaml() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    false,
 				Optional:    true,
-				Description: "IDP metadata xml data",
+				Description: "IDP metadata xml data for saml authentication",
 			},
 			"allowed_redirect_uri": {
 				Type:        schema.TypeSet,

--- a/akeyless/resource_auth_method_saml.go
+++ b/akeyless/resource_auth_method_saml.go
@@ -60,6 +60,12 @@ func resourceAuthMethodSaml() *schema.Resource {
 				Optional:    true,
 				Description: "IDP metadata url",
 			},
+            "idp_metadata_xml_data": {
+				Type:        schema.TypeString,
+				Required:    false,
+				Optional:    true,
+				Description: "IDP metadata xml data",
+			},
 			"allowed_redirect_uri": {
 				Type:        schema.TypeSet,
 				Required:    false,
@@ -91,6 +97,7 @@ func resourceAuthMethodSamlCreate(d *schema.ResourceData, m interface{}) error {
 	forceSubClaims := d.Get("force_sub_claims").(bool)
 	uniqueIdentifier := d.Get("unique_identifier").(string)
 	idpMetadataUrl := d.Get("idp_metadata_url").(string)
+    idpMetadataXmlData := d.Get("idp_metadata_xml_data").(string)
 	allowedRedirectUriSet := d.Get("allowed_redirect_uri").(*schema.Set)
 	allowedRedirectUri := common.ExpandStringList(allowedRedirectUriSet.List())
 
@@ -103,6 +110,7 @@ func resourceAuthMethodSamlCreate(d *schema.ResourceData, m interface{}) error {
 	common.GetAkeylessPtr(&body.BoundIps, boundIps)
 	common.GetAkeylessPtr(&body.ForceSubClaims, forceSubClaims)
 	common.GetAkeylessPtr(&body.IdpMetadataUrl, idpMetadataUrl)
+    common.GetAkeylessPtr(&body.IdpMetadataXmlData, idpMetadataXmlData)
 	common.GetAkeylessPtr(&body.AllowedRedirectUri, allowedRedirectUri)
 
 	rOut, _, err := client.CreateAuthMethodSAML(ctx).Body(body).Execute()
@@ -192,6 +200,13 @@ func resourceAuthMethodSamlRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
+	if rOut.AccessInfo.SamlAccessRules.IdpMetadataXml != nil {
+		err = d.Set("idp_metadata_xml_data", *rOut.AccessInfo.SamlAccessRules.IdpMetadataXml)
+		if err != nil {
+			return err
+		}
+	}
+
 	if rOut.AccessInfo.SamlAccessRules.AllowedRedirectURIs != nil {
 		err = d.Set("allowed_redirect_uri", *rOut.AccessInfo.SamlAccessRules.AllowedRedirectURIs)
 		if err != nil {
@@ -218,6 +233,7 @@ func resourceAuthMethodSamlUpdate(d *schema.ResourceData, m interface{}) error {
 	forceSubClaims := d.Get("force_sub_claims").(bool)
 	uniqueIdentifier := d.Get("unique_identifier").(string)
 	idpMetadataUrl := d.Get("idp_metadata_url").(string)
+    idpMetadataXmlData := d.Get("idp_metadata_xml").(string)
 	allowedRedirectUriSet := d.Get("allowed_redirect_uri").(*schema.Set)
 	allowedRedirectUri := common.ExpandStringList(allowedRedirectUriSet.List())
 
@@ -230,6 +246,7 @@ func resourceAuthMethodSamlUpdate(d *schema.ResourceData, m interface{}) error {
 	common.GetAkeylessPtr(&body.BoundIps, boundIps)
 	common.GetAkeylessPtr(&body.ForceSubClaims, forceSubClaims)
 	common.GetAkeylessPtr(&body.IdpMetadataUrl, idpMetadataUrl)
+    common.GetAkeylessPtr(&body.IdpMetadataXmlData, idpMetadataXmlData)
 	common.GetAkeylessPtr(&body.AllowedRedirectUri, allowedRedirectUri)
 	common.GetAkeylessPtr(&body.NewName, name)
 

--- a/docs/data-sources/auth_method.md
+++ b/docs/data-sources/auth_method.md
@@ -23,15 +23,12 @@ data "akeyless_auth_method" "api_key" {
 
 ### Required
 
-- **path** (String) The path where the secret is stored. Defaults to the latest version.
-
-### Optional
-
-- **id** (String) The ID of this resource.
+- `path` (String) The path where the secret is stored. Defaults to the latest version.
 
 ### Read-Only
 
-- **access_id** (String) The version of the secret.
-- **account_id** (String) The version of the secret.
+- `access_id` (String) The version of the secret.
+- `account_id` (String) The version of the secret.
+- `id` (String) The ID of this resource.
 
 

--- a/docs/data-sources/dynamic_secret.md
+++ b/docs/data-sources/dynamic_secret.md
@@ -23,14 +23,11 @@ data "akeyless_dynamic_secret" "secret" {
 
 ### Required
 
-- **path** (String) The path where the secret is stored. Defaults to the latest version.
-
-### Optional
-
-- **id** (String) The ID of this resource.
+- `path` (String) The path where the secret is stored. Defaults to the latest version.
 
 ### Read-Only
 
-- **value** (String, Sensitive) The secret contents.
+- `id` (String) The ID of this resource.
+- `value` (String, Sensitive) The secret contents.
 
 

--- a/docs/data-sources/k8s_auth_config.md
+++ b/docs/data-sources/k8s_auth_config.md
@@ -17,21 +17,21 @@ Gets K8S Auth config data source
 
 ### Required
 
-- **name** (String) K8S Auth config name
+- `name` (String) K8S Auth config name
 
 ### Read-Only
 
-- **am_token_expiration** (Number)
-- **auth_method_access_id** (String)
-- **auth_method_prv_key_pem** (String, Sensitive)
-- **disable_iss_validation** (Boolean)
-- **id** (String) The ID of this resource.
-- **k8s_ca_cert** (String)
-- **k8s_host** (String)
-- **k8s_issuer** (String)
-- **k8s_pub_keys_pem** (Set of String)
-- **k8s_token_reviewer_jwt** (String)
-- **protection_key** (String)
-- **use_local_ca_jwt** (Boolean)
+- `am_token_expiration` (Number)
+- `auth_method_access_id` (String)
+- `auth_method_prv_key_pem` (String, Sensitive)
+- `disable_iss_validation` (Boolean)
+- `id` (String) The ID of this resource.
+- `k8s_ca_cert` (String)
+- `k8s_host` (String)
+- `k8s_issuer` (String)
+- `k8s_pub_keys_pem` (Set of String)
+- `k8s_token_reviewer_jwt` (String)
+- `protection_key` (String)
+- `use_local_ca_jwt` (Boolean)
 
 

--- a/docs/data-sources/kube_exec_creds.md
+++ b/docs/data-sources/kube_exec_creds.md
@@ -17,22 +17,22 @@ Get credentials for authentication with Kubernetes cluster based on a PKI Cert I
 
 ### Required
 
-- **cert_issuer_name** (String) The name of the PKI certificate issuer
+- `cert_issuer_name` (String) The name of the PKI certificate issuer
 
 ### Optional
 
-- **alt_names** (String) The Subject Alternative Names to be included in the PKI certificate (in a comma-delimited list)
-- **common_name** (String) The common name to be included in the PKI certificate
-- **id** (String) The ID of this resource.
-- **key_data_base64** (String, Sensitive) pki key file contents encoded using Base64. If this option is used, the certificate will be printed to stdout
-- **uri_sans** (String) The URI Subject Alternative Names to be included in the PKI certificate (in a comma-delimited list)
+- `alt_names` (String) The Subject Alternative Names to be included in the PKI certificate (in a comma-delimited list)
+- `common_name` (String) The common name to be included in the PKI certificate
+- `key_data_base64` (String, Sensitive) pki key file contents encoded using Base64. If this option is used, the certificate will be printed to stdout
+- `uri_sans` (String) The URI Subject Alternative Names to be included in the PKI certificate (in a comma-delimited list)
 
 ### Read-Only
 
-- **api_version** (String)
-- **client_certificate_data** (String)
-- **client_key_data** (String)
-- **kind** (String)
-- **parent_certificate_data** (String)
+- `api_version` (String)
+- `client_certificate_data` (String)
+- `client_key_data` (String)
+- `id` (String) The ID of this resource.
+- `kind` (String)
+- `parent_certificate_data` (String)
 
 

--- a/docs/data-sources/producer_tmp_creds.md
+++ b/docs/data-sources/producer_tmp_creds.md
@@ -17,14 +17,11 @@ Get producer temporary credentials list data source
 
 ### Required
 
-- **name** (String) Producer Name
-
-### Optional
-
-- **id** (String) The ID of this resource.
+- `name` (String) Producer Name
 
 ### Read-Only
 
-- **value** (String)
+- `id` (String) The ID of this resource.
+- `value` (String)
 
 

--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -23,14 +23,11 @@ data "akeyless_role" "demo-role" {
 
 ### Required
 
-- **name** (String) The Role name
-
-### Optional
-
-- **id** (String) The ID of this resource.
+- `name` (String) The Role name
 
 ### Read-Only
 
-- **assoc_auth_method_with_rules** (String)
+- `assoc_auth_method_with_rules` (String)
+- `id` (String) The ID of this resource.
 
 

--- a/docs/data-sources/rotated_secret.md
+++ b/docs/data-sources/rotated_secret.md
@@ -17,15 +17,15 @@ Get rotated secret value data source
 
 ### Required
 
-- **name** (String) Secret name
+- `name` (String) Secret name
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **version** (Number) Secret version
+- `version` (Number) Secret version
 
 ### Read-Only
 
-- **value** (String, Sensitive) output
+- `id` (String) The ID of this resource.
+- `value` (String, Sensitive) output
 
 

--- a/docs/data-sources/rsa_pub.md
+++ b/docs/data-sources/rsa_pub.md
@@ -17,15 +17,12 @@ Obtain the public key from a specific RSA private key data source
 
 ### Required
 
-- **name** (String) Name of RSA key to extract the public key from
-
-### Optional
-
-- **id** (String) The ID of this resource.
+- `name` (String) Name of RSA key to extract the public key from
 
 ### Read-Only
 
-- **raw** (String)
-- **ssh** (String)
+- `id` (String) The ID of this resource.
+- `raw` (String)
+- `ssh` (String)
 
 

--- a/docs/data-sources/secret.md
+++ b/docs/data-sources/secret.md
@@ -23,15 +23,12 @@ data "akeyless_secret" "secret" {
 
 ### Required
 
-- **path** (String) The path where the secret is stored
-
-### Optional
-
-- **id** (String) The ID of this resource.
+- `path` (String) The path where the secret is stored
 
 ### Read-Only
 
-- **value** (String, Sensitive) The secret contents
-- **version** (Number) The version of the secret.
+- `id` (String) The ID of this resource.
+- `value` (String, Sensitive) The secret contents
+- `version` (Number) The version of the secret.
 
 

--- a/docs/data-sources/static_secret.md
+++ b/docs/data-sources/static_secret.md
@@ -23,15 +23,12 @@ data "akeyless_static_secret" "secret" {
 
 ### Required
 
-- **path** (String) The path where the secret is stored. Defaults to the latest version.
-
-### Optional
-
-- **id** (String) The ID of this resource.
+- `path` (String) The path where the secret is stored. Defaults to the latest version.
 
 ### Read-Only
 
-- **value** (String, Sensitive) The secret contents.
-- **version** (Number) The version of the secret.
+- `id` (String) The ID of this resource.
+- `value` (String, Sensitive) The secret contents.
+- `version` (Number) The version of the secret.
 
 

--- a/docs/data-sources/tags.md
+++ b/docs/data-sources/tags.md
@@ -17,14 +17,11 @@ Get Auth Method details data source
 
 ### Required
 
-- **name** (String) The item name
-
-### Optional
-
-- **id** (String) The ID of this resource.
+- `name` (String) The item name
 
 ### Read-Only
 
-- **tags** (Set of String)
+- `id` (String) The ID of this resource.
+- `tags` (Set of String)
 
 

--- a/docs/data-sources/target.md
+++ b/docs/data-sources/target.md
@@ -17,24 +17,24 @@ Get target data source
 
 ### Required
 
-- **name** (String) Target name
+- `name` (String) Target name
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **show_versions** (Boolean) Include all target versions in reply
+- `show_versions` (Boolean) Include all target versions in reply
 
 ### Read-Only
 
-- **client_permissions** (Set of String)
-- **comment** (String)
-- **last_version** (Number)
-- **protection_key_name** (String)
-- **target_id** (Number)
-- **target_items_assoc** (String)
-- **target_name** (String)
-- **target_type** (String)
-- **target_versions** (String)
-- **with_customer_fragment** (Boolean)
+- `client_permissions` (Set of String)
+- `comment` (String)
+- `id` (String) The ID of this resource.
+- `last_version` (Number)
+- `protection_key_name` (String)
+- `target_id` (Number)
+- `target_items_assoc` (String)
+- `target_name` (String)
+- `target_type` (String)
+- `target_versions` (String)
+- `with_customer_fragment` (Boolean)
 
 

--- a/docs/data-sources/target_details.md
+++ b/docs/data-sources/target_details.md
@@ -17,21 +17,21 @@ Get target details data source
 
 ### Required
 
-- **name** (String) Target name
+- `name` (String) Target name
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **show_versions** (Boolean) Include all target versions in reply
-- **target_version** (Number) Target version
+- `show_versions` (Boolean) Include all target versions in reply
+- `target_version` (Number) Target version
 
 ### Read-Only
 
-- **host** (String)
-- **password** (String, Sensitive)
-- **port** (String)
-- **private_key** (String)
-- **private_key_password** (String)
-- **username** (String)
+- `host` (String)
+- `id` (String) The ID of this resource.
+- `password` (String, Sensitive)
+- `port` (String)
+- `private_key` (String)
+- `private_key_password` (String)
+- `username` (String)
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,20 +109,20 @@ output "auth_method" {
 
 ### Optional
 
-- **api_gateway_address** (String) Origin URL of the API Gateway server. This is a URL with a scheme, a hostname and a port.
-- **api_key_login** (Block List) A configuration block, described below, that attempts to authenticate using API-Key. (see [below for nested schema](#nestedblock--api_key_login))
-- **aws_iam_login** (Block List) A configuration block, described below, that attempts to authenticate using AWS-IAM authentication credentials. (see [below for nested schema](#nestedblock--aws_iam_login))
-- **azure_ad_login** (Block List) A configuration block, described below, that attempts to authenticate using Azure Active Directory authentication. (see [below for nested schema](#nestedblock--azure_ad_login))
-- **email_login** (Block List) A configuration block, described below, that attempts to authenticate using email and password. (see [below for nested schema](#nestedblock--email_login))
-- **jwt_login** (Block List) A configuration block, described below, that attempts to authenticate using JWT authentication.  The JWT can be provided as a command line variable or it will be pulled out of an environment variable named AKEYLESS_AUTH_JWT. (see [below for nested schema](#nestedblock--jwt_login))
+- `api_gateway_address` (String) Origin URL of the API Gateway server. This is a URL with a scheme, a hostname and a port.
+- `api_key_login` (Block List) A configuration block, described below, that attempts to authenticate using API-Key. (see [below for nested schema](#nestedblock--api_key_login))
+- `aws_iam_login` (Block List) A configuration block, described below, that attempts to authenticate using AWS-IAM authentication credentials. (see [below for nested schema](#nestedblock--aws_iam_login))
+- `azure_ad_login` (Block List) A configuration block, described below, that attempts to authenticate using Azure Active Directory authentication. (see [below for nested schema](#nestedblock--azure_ad_login))
+- `email_login` (Block List) A configuration block, described below, that attempts to authenticate using email and password. (see [below for nested schema](#nestedblock--email_login))
+- `jwt_login` (Block List) A configuration block, described below, that attempts to authenticate using JWT authentication.  The JWT can be provided as a command line variable or it will be pulled out of an environment variable named AKEYLESS_AUTH_JWT. (see [below for nested schema](#nestedblock--jwt_login))
 
 <a id="nestedblock--api_key_login"></a>
 ### Nested Schema for `api_key_login`
 
 Required:
 
-- **access_id** (String)
-- **access_key** (String, Sensitive)
+- `access_id` (String)
+- `access_key` (String, Sensitive)
 
 
 <a id="nestedblock--aws_iam_login"></a>
@@ -130,7 +130,7 @@ Required:
 
 Required:
 
-- **access_id** (String)
+- `access_id` (String)
 
 
 <a id="nestedblock--azure_ad_login"></a>
@@ -138,7 +138,7 @@ Required:
 
 Required:
 
-- **access_id** (String)
+- `access_id` (String)
 
 
 <a id="nestedblock--email_login"></a>
@@ -146,8 +146,8 @@ Required:
 
 Required:
 
-- **admin_email** (String)
-- **admin_password** (String)
+- `admin_email` (String)
+- `admin_password` (String)
 
 
 <a id="nestedblock--jwt_login"></a>
@@ -155,5 +155,5 @@ Required:
 
 Required:
 
-- **access_id** (String)
-- **jwt** (String, Sensitive)
+- `access_id` (String)
+- `jwt` (String, Sensitive)

--- a/docs/resources/associate_role_auth_method.md
+++ b/docs/resources/associate_role_auth_method.md
@@ -17,13 +17,16 @@ Association between role and auth method
 
 ### Required
 
-- **am_name** (String) The auth method to associate
-- **role_name** (String) The role to associate
+- `am_name` (String) The auth method to associate
+- `role_name` (String) The role to associate
 
 ### Optional
 
-- **case_sensitive** (String) Treat sub claims as case-sensitive
-- **id** (String) The ID of this resource.
-- **sub_claims** (Map of String) key/val of sub claims, e.g group=admins,developers
+- `case_sensitive` (String) Treat sub claims as case-sensitive
+- `sub_claims` (Map of String) key/val of sub claims, e.g group=admins,developers
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/auth_method.md
+++ b/docs/resources/auth_method.md
@@ -45,6 +45,7 @@ resource "akeyless_auth_method" "aws_iam" {
   }
 }
 
+
 data "akeyless_auth_method" "api_key" {
   path = "auth-method-api-key"
 }
@@ -59,40 +60,44 @@ output "api_key" {
 
 ### Required
 
-- **path** (String) The path where the Auth Method will be stored
+- `path` (String) The path where the Auth Method will be stored
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **aws_iam** (Block List) A configuration block, described below, using AWS-IAM Auth Method (see [below for nested schema](#nestedblock--aws_iam))
-- **azure_ad** (Block List) A configuration block, described below, using Azure AD Auth Method (see [below for nested schema](#nestedblock--azure_ad))
-- **bound_ips** (String) A CIDR whitelist with the IPs that the access is restricted to
-- **gcp** (Block List) A configuration block, described below, using Auth Method API-Key (see [below for nested schema](#nestedblock--gcp))
-- **id** (String) The ID of this resource.
-- **saml** (Block List) A configuration block, described below, using SAML Auth Method (see [below for nested schema](#nestedblock--saml))
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `api_key` (Block List) A configuration block, described below, using API-Key Auth Method (see [below for nested schema](#nestedblock--api_key))
+- `aws_iam` (Block List) A configuration block, described below, using AWS-IAM Auth Method (see [below for nested schema](#nestedblock--aws_iam))
+- `azure_ad` (Block List) A configuration block, described below, using Azure AD Auth Method (see [below for nested schema](#nestedblock--azure_ad))
+- `bound_ips` (String) A CIDR whitelist with the IPs that the access is restricted to
+- `gcp` (Block List) A configuration block, described below, using Auth Method API-Key (see [below for nested schema](#nestedblock--gcp))
+- `saml` (Block List) A configuration block, described below, using SAML Auth Method (see [below for nested schema](#nestedblock--saml))
 
 ### Read-Only
 
-- **access_id** (String) Auth Method access ID
-- **access_key** (String, Sensitive) Auth Method access key
-- **api_key** (Block List) A configuration block, described below, using API-Key Auth Method (see [below for nested schema](#nestedblock--api_key))
+- `access_id` (String) Auth Method access ID
+- `access_key` (String, Sensitive) Auth Method access key
+- `id` (String) The ID of this resource.
+
+<a id="nestedblock--api_key"></a>
+### Nested Schema for `api_key`
+
 
 <a id="nestedblock--aws_iam"></a>
 ### Nested Schema for `aws_iam`
 
 Required:
 
-- **bound_aws_account_id** (Set of String) A list of AWS account-IDs that the access is restricted to
+- `bound_aws_account_id` (Set of String) A list of AWS account-IDs that the access is restricted to
 
 Optional:
 
-- **bound_arn** (Set of String) A list of full arns that the access is restricted to
-- **bound_resource_id** (Set of String) A list of full resource ids that the access is restricted to
-- **bound_role_id** (Set of String) A list of full role ids that the access is restricted to
-- **bound_role_name** (Set of String) A list of full role-name that the access is restricted to
-- **bound_user_id** (Set of String) A list of full user ids that the access is restricted to
-- **bound_user_name** (Set of String) A list of full user-name that the access is restricted to
-- **sts_url** (String) STS URL (default: https://sts.amazonaws.com)
+- `bound_arn` (Set of String) A list of full arns that the access is restricted to
+- `bound_resource_id` (Set of String) A list of full resource ids that the access is restricted to
+- `bound_role_id` (Set of String) A list of full role ids that the access is restricted to
+- `bound_role_name` (Set of String) A list of full role-name that the access is restricted to
+- `bound_user_id` (Set of String) A list of full user ids that the access is restricted to
+- `bound_user_name` (Set of String) A list of full user-name that the access is restricted to
+- `sts_url` (String) STS URL (default: https://sts.amazonaws.com)
 
 
 <a id="nestedblock--azure_ad"></a>
@@ -100,21 +105,21 @@ Optional:
 
 Required:
 
-- **bound_tenant_id** (String) The Azure tenant id that the access is restricted to
+- `bound_tenant_id` (String) The Azure tenant id that the access is restricted to
 
 Optional:
 
-- **bound_group_id** (Set of String) A list of group ids that the access is restricted to
-- **bound_providers** (Set of String) A list of resource providers that the access is restricted to (e.g, Microsoft.Compute, Microsoft.ManagedIdentity, etc)
-- **bound_resource_id** (Set of String) A list of full resource ids that the access is restricted to
-- **bound_resource_names** (Set of String) A list of resource names that the access is restricted to (e.g, a virtual machine name, scale set name, etc)
-- **bound_resource_types** (Set of String) A list of resource types that the access is restricted to (e.g, virtualMachines, userAssignedIdentities, etc)
-- **bound_rg_id** (Set of String) A list of resource groups that the access is restricted to
-- **bound_spid** (Set of String) A list of service principal IDs that the access is restricted to
-- **bound_sub_id** (Set of String) A list of subscription ids that the access is restricted to
-- **custom_audience** (String) The audience in the JWT
-- **custom_issuer** (String) Issuer URL
-- **jwks_uri** (String) The URL to the JSON Web Key Set (JWKS) that containing the public keys that should be used to verify any JSON Web Token (JWT) issued by the authorization server
+- `bound_group_id` (Set of String) A list of group ids that the access is restricted to
+- `bound_providers` (Set of String) A list of resource providers that the access is restricted to (e.g, Microsoft.Compute, Microsoft.ManagedIdentity, etc)
+- `bound_resource_id` (Set of String) A list of full resource ids that the access is restricted to
+- `bound_resource_names` (Set of String) A list of resource names that the access is restricted to (e.g, a virtual machine name, scale set name, etc)
+- `bound_resource_types` (Set of String) A list of resource types that the access is restricted to (e.g, virtualMachines, userAssignedIdentities, etc)
+- `bound_rg_id` (Set of String) A list of resource groups that the access is restricted to
+- `bound_spid` (Set of String) A list of service principal IDs that the access is restricted to
+- `bound_sub_id` (Set of String) A list of subscription ids that the access is restricted to
+- `custom_audience` (String) The audience in the JWT
+- `custom_issuer` (String) Issuer URL
+- `jwks_uri` (String) The URL to the JSON Web Key Set (JWKS) that containing the public keys that should be used to verify any JSON Web Token (JWT) issued by the authorization server
 
 
 <a id="nestedblock--gcp"></a>
@@ -122,22 +127,22 @@ Optional:
 
 Required:
 
-- **service_account_creds_data** (String) Service Account creds data, base64 encoded
+- `service_account_creds_data` (String) Service Account creds data, base64 encoded
 
 Optional:
 
-- **audience** (String) The audience to verify in the JWT received by the client
-- **gce** (Block List) IAM GCE Auth Method (see [below for nested schema](#nestedblock--gcp--gce))
-- **iam** (Block List) IAM GCP Auth Method (see [below for nested schema](#nestedblock--gcp--iam))
+- `audience` (String) The audience to verify in the JWT received by the client
+- `gce` (Block List) IAM GCE Auth Method (see [below for nested schema](#nestedblock--gcp--gce))
+- `iam` (Block List) IAM GCP Auth Method (see [below for nested schema](#nestedblock--gcp--iam))
 
 <a id="nestedblock--gcp--gce"></a>
 ### Nested Schema for `gcp.gce`
 
 Optional:
 
-- **bound_labels** (Set of String) GCE only. A list of GCP labels formatted as "key:value" pairs that must be set on instances in order to authenticate
-- **bound_regions** (Set of String) GCE only. A list of regions. GCE instances must belong to any of the provided regions in order to authenticate
-- **bound_zones** (Set of String) GCE only. A list of zones. GCE instances must belong to any of the provided zones in order to authenticate
+- `bound_labels` (Set of String) GCE only. A list of GCP labels formatted as "key:value" pairs that must be set on instances in order to authenticate
+- `bound_regions` (Set of String) GCE only. A list of regions. GCE instances must belong to any of the provided regions in order to authenticate
+- `bound_zones` (Set of String) GCE only. A list of zones. GCE instances must belong to any of the provided zones in order to authenticate
 
 
 <a id="nestedblock--gcp--iam"></a>
@@ -145,7 +150,7 @@ Optional:
 
 Optional:
 
-- **bound_service_accounts** (Set of String) IAM only. A list of Service Accounts. Clients must belong to any of the provided service accounts in order to authenticate
+- `bound_service_accounts` (Set of String) IAM only. A list of Service Accounts. Clients must belong to any of the provided service accounts in order to authenticate
 
 
 
@@ -154,11 +159,11 @@ Optional:
 
 Required:
 
-- **idp_metadata_url** (String) IDP metadata url
-- **unique_identifier** (String) A unique identifier (ID) value should be configured for OAuth2, LDAP and SAML authentication method types and is usually a value such as the email, username, or upn for example
+- `unique_identifier` (String) A unique identifier (ID) value should be configured for OAuth2, LDAP and SAML authentication method types and is usually a value such as the email, username, or upn for example
 
+Optional:
 
-<a id="nestedblock--api_key"></a>
-### Nested Schema for `api_key`
+- `idp_metadata_url` (String) IDP metadata url
+- `idp_metadata_xml_data` (String) IDP metadata xml data
 
 

--- a/docs/resources/auth_method_api_key.md
+++ b/docs/resources/auth_method_api_key.md
@@ -17,15 +17,18 @@ AWS API Key Auth Method Resource
 
 ### Required
 
-- **name** (String) Auth Method name
+- `name` (String) Auth Method name
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **access_id** (String) Auth Method access ID
-- **access_key** (String, Sensitive) Auth Method access key
-- **bound_ips** (Set of String) A CIDR whitelist with the IPs that the access is restricted to
-- **force_sub_claims** (Boolean) enforce role-association must include sub claims
-- **id** (String) The ID of this resource.
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `access_id` (String) Auth Method access ID
+- `access_key` (String, Sensitive) Auth Method access key
+- `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
+- `force_sub_claims` (Boolean) enforce role-association must include sub claims
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/auth_method_aws_iam.md
+++ b/docs/resources/auth_method_aws_iam.md
@@ -17,22 +17,25 @@ AWS IAM Auth Method Resource
 
 ### Required
 
-- **bound_aws_account_id** (Set of String) A list of AWS account-IDs that the access is restricted to
-- **name** (String) Auth Method name
+- `bound_aws_account_id` (Set of String) A list of AWS account-IDs that the access is restricted to
+- `name` (String) Auth Method name
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **access_id** (String) Auth Method access ID
-- **bound_arn** (Set of String) A list of full arns that the access is restricted to
-- **bound_ips** (Set of String) A CIDR whitelist with the IPs that the access is restricted to
-- **bound_resource_id** (Set of String) A list of full resource ids that the access is restricted to
-- **bound_role_id** (Set of String) A list of full role ids that the access is restricted to
-- **bound_role_name** (Set of String) A list of full role-name that the access is restricted to
-- **bound_user_id** (Set of String) A list of full user ids that the access is restricted to
-- **bound_user_name** (Set of String) A list of full user-name that the access is restricted to
-- **force_sub_claims** (Boolean) enforce role-association must include sub claims
-- **id** (String) The ID of this resource.
-- **sts_url** (String) sts URL
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `access_id` (String) Auth Method access ID
+- `bound_arn` (Set of String) A list of full arns that the access is restricted to
+- `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
+- `bound_resource_id` (Set of String) A list of full resource ids that the access is restricted to
+- `bound_role_id` (Set of String) A list of full role ids that the access is restricted to
+- `bound_role_name` (Set of String) A list of full role-name that the access is restricted to
+- `bound_user_id` (Set of String) A list of full user ids that the access is restricted to
+- `bound_user_name` (Set of String) A list of full user-name that the access is restricted to
+- `force_sub_claims` (Boolean) enforce role-association must include sub claims
+- `sts_url` (String) sts URL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/auth_method_azure_ad.md
+++ b/docs/resources/auth_method_azure_ad.md
@@ -17,26 +17,29 @@ Azure Active Directory Auth Method Resource
 
 ### Required
 
-- **bound_tenant_id** (String) The Azure tenant id that the access is restricted to
-- **name** (String) Auth Method name
+- `bound_tenant_id` (String) The Azure tenant id that the access is restricted to
+- `name` (String) Auth Method name
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **access_id** (String) Auth Method access ID
-- **audience** (String) The audience in the JWT
-- **bound_group_id** (Set of String) A list of group ids that the access is restricted to
-- **bound_ips** (Set of String) A CIDR whitelist with the IPs that the access is restricted to
-- **bound_providers** (Set of String) A list of resource providers that the access is restricted to (e.g, Microsoft.Compute, Microsoft.ManagedIdentity, etc)
-- **bound_resource_id** (Set of String) A list of full resource ids that the access is restricted to
-- **bound_resource_names** (Set of String) A list of resource names that the access is restricted to (e.g, a virtual machine name, scale set name, etc).
-- **bound_resource_types** (Set of String) A list of resource types that the access is restricted to (e.g, virtualMachines, userAssignedIdentities, etc)
-- **bound_rg_id** (Set of String) A list of resource groups that the access is restricted to
-- **bound_spid** (Set of String) A list of service principal IDs that the access is restricted to
-- **bound_sub_id** (Set of String) A list of subscription ids that the access is restricted to
-- **force_sub_claims** (Boolean) enforce role-association must include sub claims
-- **id** (String) The ID of this resource.
-- **issuer** (String) Issuer URL
-- **jwks_uri** (String) The URL to the JSON Web Key Set (JWKS) that containing the public keys that should be used to verify any JSON Web Token (JWT) issued by the authorization server.
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `access_id` (String) Auth Method access ID
+- `audience` (String) The audience in the JWT
+- `bound_group_id` (Set of String) A list of group ids that the access is restricted to
+- `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
+- `bound_providers` (Set of String) A list of resource providers that the access is restricted to (e.g, Microsoft.Compute, Microsoft.ManagedIdentity, etc)
+- `bound_resource_id` (Set of String) A list of full resource ids that the access is restricted to
+- `bound_resource_names` (Set of String) A list of resource names that the access is restricted to (e.g, a virtual machine name, scale set name, etc).
+- `bound_resource_types` (Set of String) A list of resource types that the access is restricted to (e.g, virtualMachines, userAssignedIdentities, etc)
+- `bound_rg_id` (Set of String) A list of resource groups that the access is restricted to
+- `bound_spid` (Set of String) A list of service principal IDs that the access is restricted to
+- `bound_sub_id` (Set of String) A list of subscription ids that the access is restricted to
+- `force_sub_claims` (Boolean) enforce role-association must include sub claims
+- `issuer` (String) Issuer URL
+- `jwks_uri` (String) The URL to the JSON Web Key Set (JWKS) that containing the public keys that should be used to verify any JSON Web Token (JWT) issued by the authorization server.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/auth_method_gcp.md
+++ b/docs/resources/auth_method_gcp.md
@@ -17,22 +17,25 @@ GCE Auth Method Resource
 
 ### Required
 
-- **name** (String) Auth Method name
-- **type** (String) The type of the GCP Auth Method (iam/gce)
+- `name` (String) Auth Method name
+- `type` (String) The type of the GCP Auth Method (iam/gce)
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **access_id** (String) Auth Method access ID
-- **audience** (String) The audience to verify in the JWT received by the client
-- **bound_ips** (Set of String) A CIDR whitelist with the IPs that the access is restricted to
-- **bound_labels** (Set of String) GCE only. A list of GCP labels formatted as key:value pairs that must be set on instances in order to authenticate. For multiple values repeat this flag.
-- **bound_projects** (Set of String) A list of GCP project IDs. Clients must belong to any of the provided projects in order to authenticate. For multiple values repeat this flag.
-- **bound_regions** (Set of String) GCE only. A list of regions. GCE instances must belong to any of the provided regions in order to authenticate. For multiple values repeat this flag.
-- **bound_service_accounts** (Set of String) A list of Service Accounts. Clients must belong to any of the provided service accounts in order to authenticate. For multiple values repeat this flag.
-- **bound_zones** (Set of String) GCE only. A list of zones. GCE instances must belong to any of the provided zones in order to authenticate. For multiple values repeat this flag.
-- **force_sub_claims** (Boolean) enforce role-association must include sub claims
-- **id** (String) The ID of this resource.
-- **service_account_creds_data** (String) Service Account creds data, base64 encoded
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `access_id` (String) Auth Method access ID
+- `audience` (String) The audience to verify in the JWT received by the client
+- `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
+- `bound_labels` (Set of String) GCE only. A list of GCP labels formatted as key:value pairs that must be set on instances in order to authenticate. For multiple values repeat this flag.
+- `bound_projects` (Set of String) A list of GCP project IDs. Clients must belong to any of the provided projects in order to authenticate. For multiple values repeat this flag.
+- `bound_regions` (Set of String) GCE only. A list of regions. GCE instances must belong to any of the provided regions in order to authenticate. For multiple values repeat this flag.
+- `bound_service_accounts` (Set of String) A list of Service Accounts. Clients must belong to any of the provided service accounts in order to authenticate. For multiple values repeat this flag.
+- `bound_zones` (Set of String) GCE only. A list of zones. GCE instances must belong to any of the provided zones in order to authenticate. For multiple values repeat this flag.
+- `force_sub_claims` (Boolean) enforce role-association must include sub claims
+- `service_account_creds_data` (String) Service Account creds data, base64 encoded
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/auth_method_k8s.md
+++ b/docs/resources/auth_method_k8s.md
@@ -17,21 +17,24 @@ Kubernetes Auth Method Resource
 
 ### Required
 
-- **name** (String) Auth Method name
+- `name` (String) Auth Method name
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **access_id** (String) Auth Method access ID
-- **audience** (String) The audience in the Kubernetes JWT that the access is restricted to
-- **bound_ips** (Set of String) A CIDR whitelist with the IPs that the access is restricted to
-- **bound_namespaces** (Set of String) A list of namespaces that the access is restricted to
-- **bound_pod_names** (Set of String) A list of pod names that the access is restricted to
-- **bound_sa_names** (Set of String) A list of service account names that the access is restricted to
-- **force_sub_claims** (Boolean) enforce role-association must include sub claims
-- **gen_key** (String) If this flag is set to true, there is no need to manually provide a public key for the Kubernetes Auth Method, and instead, a key pair, will be generated as part of the command and the private part of the key will be returned (the private key is required for the K8S Auth Config in the Akeyless Gateway)
-- **id** (String) The ID of this resource.
-- **private_key** (String) The generated private key
-- **public_key** (String) The generated public key
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `access_id` (String) Auth Method access ID
+- `audience` (String) The audience in the Kubernetes JWT that the access is restricted to
+- `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
+- `bound_namespaces` (Set of String) A list of namespaces that the access is restricted to
+- `bound_pod_names` (Set of String) A list of pod names that the access is restricted to
+- `bound_sa_names` (Set of String) A list of service account names that the access is restricted to
+- `force_sub_claims` (Boolean) enforce role-association must include sub claims
+- `gen_key` (String) If this flag is set to true, there is no need to manually provide a public key for the Kubernetes Auth Method, and instead, a key pair, will be generated as part of the command and the private part of the key will be returned (the private key is required for the K8S Auth Config in the Akeyless Gateway)
+- `private_key` (String) The generated private key
+- `public_key` (String) The generated public key
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/auth_method_oauth2.md
+++ b/docs/resources/auth_method_oauth2.md
@@ -17,19 +17,22 @@ AOAuth2 Auth Method Resource
 
 ### Required
 
-- **jwks_uri** (String) The URL to the JSON Web Key Set (JWKS) that containing the public keys that should be used to verify any JSON Web Token (JWT) issued by the authorization server.
-- **name** (String) Auth Method name
-- **unique_identifier** (String) A unique identifier (ID) value should be configured for OAuth2, LDAP and SAML authentication method types and is usually a value such as the email, username, or upn for example. Whenever a user logs in with a token, these authentication types issue a sub claim that contains details uniquely identifying that user. This sub claim includes a key containing the ID value that you configured, and is used to distinguish between different users from within the same organization.
+- `jwks_uri` (String) The URL to the JSON Web Key Set (JWKS) that containing the public keys that should be used to verify any JSON Web Token (JWT) issued by the authorization server.
+- `name` (String) Auth Method name
+- `unique_identifier` (String) A unique identifier (ID) value should be configured for OAuth2, LDAP and SAML authentication method types and is usually a value such as the email, username, or upn for example. Whenever a user logs in with a token, these authentication types issue a sub claim that contains details uniquely identifying that user. This sub claim includes a key containing the ID value that you configured, and is used to distinguish between different users from within the same organization.
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **access_id** (String) Auth Method access ID
-- **audience** (String) The audience in the JWT
-- **bound_client_ids** (Set of String) The clients ids that the access is restricted to
-- **bound_ips** (Set of String) A CIDR whitelist with the IPs that the access is restricted to
-- **force_sub_claims** (Boolean) enforce role-association must include sub claims
-- **id** (String) The ID of this resource.
-- **issuer** (String) Issuer URL
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `access_id` (String) Auth Method access ID
+- `audience` (String) The audience in the JWT
+- `bound_client_ids` (Set of String) The clients ids that the access is restricted to
+- `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
+- `force_sub_claims` (Boolean) enforce role-association must include sub claims
+- `issuer` (String) Issuer URL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/auth_method_oidc.md
+++ b/docs/resources/auth_method_oidc.md
@@ -17,19 +17,22 @@ OIDC Auth Method Resource
 
 ### Required
 
-- **name** (String) Auth Method name
-- **unique_identifier** (String) A unique identifier (ID) value should be configured for OIDC, OAuth2, LDAP and SAML authentication method types and is usually a value such as the email, username, or upn for example. Whenever a user logs in with a token, these authentication types issue a sub claim that contains details uniquely identifying that user. This sub claim includes a key containing the ID value that you configured, and is used to distinguish between different users from within the same organization.
+- `name` (String) Auth Method name
+- `unique_identifier` (String) A unique identifier (ID) value should be configured for OIDC, OAuth2, LDAP and SAML authentication method types and is usually a value such as the email, username, or upn for example. Whenever a user logs in with a token, these authentication types issue a sub claim that contains details uniquely identifying that user. This sub claim includes a key containing the ID value that you configured, and is used to distinguish between different users from within the same organization.
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **access_id** (String) Auth Method access ID
-- **allowed_redirect_uri** (Set of String) Allowed redirect URIs after the authentication (default is https://console.akeyless.io/login-oidc to enable OIDC via Akeyless Console and  http://127.0.0.1:* to enable OIDC via akeyless CLI)
-- **bound_ips** (Set of String) A CIDR whitelist with the IPs that the access is restricted to
-- **client_id** (String) Client ID
-- **client_secret** (String) Client Secret
-- **force_sub_claims** (Boolean) enforce role-association must include sub claims
-- **id** (String) The ID of this resource.
-- **issuer** (String) Issuer URL
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `access_id` (String) Auth Method access ID
+- `allowed_redirect_uri` (Set of String) Allowed redirect URIs after the authentication (default is https://console.akeyless.io/login-oidc to enable OIDC via Akeyless Console and  http://127.0.0.1:* to enable OIDC via akeyless CLI)
+- `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
+- `client_id` (String) Client ID
+- `client_secret` (String) Client Secret
+- `force_sub_claims` (Boolean) enforce role-association must include sub claims
+- `issuer` (String) Issuer URL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/auth_method_saml.md
+++ b/docs/resources/auth_method_saml.md
@@ -17,17 +17,21 @@ SAML Auth Method Resource
 
 ### Required
 
-- **name** (String) Auth Method name
-- **unique_identifier** (String) A unique identifier (ID) value should be configured for OAuth2, LDAP and SAML authentication method types and is usually a value such as the email, username, or upn for example. Whenever a user logs in with a token, these authentication types issue a sub claim that contains details uniquely identifying that user. This sub claim includes a key containing the ID value that you configured, and is used to distinguish between different users from within the same organization.
+- `name` (String) Auth Method name
+- `unique_identifier` (String) A unique identifier (ID) value should be configured for OAuth2, LDAP and SAML authentication method types and is usually a value such as the email, username, or upn for example. Whenever a user logs in with a token, these authentication types issue a sub claim that contains details uniquely identifying that user. This sub claim includes a key containing the ID value that you configured, and is used to distinguish between different users from within the same organization.
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **access_id** (String) Auth Method access ID
-- **allowed_redirect_uri** (Set of String) Allowed redirect URIs after the authentication (default is https://console.akeyless.io/login-saml to enable SAML via Akeyless Console and  http://127.0.0.1:* to enable SAML via akeyless CLI)
-- **bound_ips** (Set of String) A CIDR whitelist with the IPs that the access is restricted to
-- **force_sub_claims** (Boolean) enforce role-association must include sub claims
-- **id** (String) The ID of this resource.
-- **idp_metadata_url** (String) IDP metadata url
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `access_id` (String) Auth Method access ID
+- `allowed_redirect_uri` (Set of String) Allowed redirect URIs after the authentication (default is https://console.akeyless.io/login-saml to enable SAML via Akeyless Console and  http://127.0.0.1:* to enable SAML via akeyless CLI)
+- `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
+- `force_sub_claims` (Boolean) enforce role-association must include sub claims
+- `idp_metadata_url` (String) IDP metadata url
+- `idp_metadata_xml_data` (String) IDP metadata xml data for saml authentication
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/auth_method_universal_identity.md
+++ b/docs/resources/auth_method_universal_identity.md
@@ -17,17 +17,20 @@ Akeyless Universal Identity Auth Method Resource
 
 ### Required
 
-- **name** (String) Auth Method name
+- `name` (String) Auth Method name
 
 ### Optional
 
-- **access_expires** (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
-- **access_id** (String) Auth Method access ID
-- **bound_ips** (Set of String) A CIDR whitelist with the IPs that the access is restricted to
-- **deny_inheritance** (Boolean) Deny from root to create children
-- **deny_rotate** (Boolean) Deny from the token to rotate
-- **force_sub_claims** (Boolean) enforce role-association must include sub claims
-- **id** (String) The ID of this resource.
-- **ttl** (Number) Token ttl (in minutes)
+- `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
+- `access_id` (String) Auth Method access ID
+- `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
+- `deny_inheritance` (Boolean) Deny from root to create children
+- `deny_rotate` (Boolean) Deny from the token to rotate
+- `force_sub_claims` (Boolean) enforce role-association must include sub claims
+- `ttl` (Number) Token ttl (in minutes)
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/dfc_key.md
+++ b/docs/resources/dfc_key.md
@@ -17,14 +17,17 @@ DFC Key resource
 
 ### Required
 
-- **alg** (String) DFCKey type; options: [AES128GCM, AES256GCM, AES128SIV, AES256SIV, RSA1024, RSA2048, RSA3072, RSA4096]
-- **name** (String) DFCKey name
+- `alg` (String) DFCKey type; options: [AES128GCM, AES256GCM, AES128SIV, AES256SIV, RSA1024, RSA2048, RSA3072, RSA4096]
+- `name` (String) DFCKey name
 
 ### Optional
 
-- **customer_frg_id** (String) The customer fragment ID that will be used to create the DFC key (if empty, the key will be created independently of a customer fragment)
-- **id** (String) The ID of this resource.
-- **metadata** (String) Metadata about the DFC key
-- **tags** (Set of String) List of the tags attached to this DFC key. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `customer_frg_id` (String) The customer fragment ID that will be used to create the DFC key (if empty, the key will be created independently of a customer fragment)
+- `metadata` (String) Metadata about the DFC key
+- `tags` (Set of String) List of the tags attached to this DFC key. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/k8s_auth_config.md
+++ b/docs/resources/k8s_auth_config.md
@@ -17,18 +17,21 @@ K8S Auth config
 
 ### Required
 
-- **access_id** (String) The access ID of the Kubernetes auth method
-- **name** (String) K8S Auth config name
+- `access_id` (String) The access ID of the Kubernetes auth method
+- `name` (String) K8S Auth config name
 
 ### Optional
 
-- **config_encryption_key_name** (String) Encrypt K8S Auth config with following key
-- **id** (String) The ID of this resource.
-- **k8s_ca_cert** (String) Base-64 encoded certificate to use to call into the kubernetes API
-- **k8s_host** (String) The URL of the kubernetes API server
-- **k8s_issuer** (String) The Kubernetes JWT issuer name. If not set, kubernetes/serviceaccount will be used as an issuer.
-- **signing_key** (String) The private key (in base64 encoded of the PEM format) associated with the public key defined in the Kubernetes auth
-- **token_exp** (Number) Time in seconds of expiration of the Akeyless Kube Auth Method token
-- **token_reviewer_jwt** (String) A Kubernetes service account JWT used to access the TokenReview API to validate other JWTs. If not set, the JWT submitted in the authentication process will be used to access the Kubernetes TokenReview API.
+- `config_encryption_key_name` (String) Encrypt K8S Auth config with following key
+- `k8s_ca_cert` (String) Base-64 encoded certificate to use to call into the kubernetes API
+- `k8s_host` (String) The URL of the kubernetes API server
+- `k8s_issuer` (String) The Kubernetes JWT issuer name. If not set, kubernetes/serviceaccount will be used as an issuer.
+- `signing_key` (String) The private key (in base64 encoded of the PEM format) associated with the public key defined in the Kubernetes auth
+- `token_exp` (Number) Time in seconds of expiration of the Akeyless Kube Auth Method token
+- `token_reviewer_jwt` (String) A Kubernetes service account JWT used to access the TokenReview API to validate other JWTs. If not set, the JWT submitted in the authentication process will be used to access the Kubernetes TokenReview API.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/pki_cert_issuer.md
+++ b/docs/resources/pki_cert_issuer.md
@@ -17,31 +17,34 @@ PKI Cert Issuer  resource
 
 ### Required
 
-- **name** (String) PKI certificate issuer name
-- **signer_key_name** (String) A key to sign the certificate with
-- **ttl** (Number) he requested Time To Live for the certificate, in seconds
+- `name` (String) PKI certificate issuer name
+- `signer_key_name` (String) A key to sign the certificate with
+- `ttl` (Number) he requested Time To Live for the certificate, in seconds
 
 ### Optional
 
-- **allow_any_name** (Boolean) If set, clients can request certificates for any CN
-- **allow_subdomains** (Boolean) If set, clients can request certificates for subdomains and wildcard subdomains of the allowed domains
-- **allowed_domains** (String) A list of the allowed domains that clients can request to be included in the certificate (in a comma-delimited list)
-- **allowed_uri_sans** (String) A list of the allowed URIs that clients can request to be included in the certificate as part of the URI Subject Alternative Names (in a comma-delimited list)
-- **client_flag** (Boolean) If set, certificates will be flagged for client auth use
-- **code_signing_flag** (Boolean) If set, certificates will be flagged for code signing use
-- **country** (String) A comma-separated list of the country that will be set in the issued certificate
-- **id** (String) The ID of this resource.
-- **key_usage** (String) A comma-separated string or list of key usages
-- **locality** (String) A comma-separated list of the locality that will be set in the issued certificate
-- **metadata** (String) A metadata about the issuer
-- **not_enforce_hostnames** (Boolean) If set, any names are allowed for CN and SANs in the certificate and not only a valid host name
-- **not_require_cn** (Boolean) If set, clients can request certificates without a CN
-- **organizational_units** (String) A comma-separated list of organizational units (OU) that will be set in the issued certificate
-- **organizations** (String) A comma-separated list of organizations (O) that will be set in the issued certificate
-- **postal_code** (String) A comma-separated list of the postal code that will be set in the issued certificate
-- **province** (String) A comma-separated list of the province that will be set in the issued certificate
-- **server_flag** (Boolean) If set, certificates will be flagged for server auth use
-- **street_address** (String) A comma-separated list of the street address that will be set in the issued certificate
-- **tags** (Set of String) List of the tags attached to this key. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
+- `allow_any_name` (Boolean) If set, clients can request certificates for any CN
+- `allow_subdomains` (Boolean) If set, clients can request certificates for subdomains and wildcard subdomains of the allowed domains
+- `allowed_domains` (String) A list of the allowed domains that clients can request to be included in the certificate (in a comma-delimited list)
+- `allowed_uri_sans` (String) A list of the allowed URIs that clients can request to be included in the certificate as part of the URI Subject Alternative Names (in a comma-delimited list)
+- `client_flag` (Boolean) If set, certificates will be flagged for client auth use
+- `code_signing_flag` (Boolean) If set, certificates will be flagged for code signing use
+- `country` (String) A comma-separated list of the country that will be set in the issued certificate
+- `key_usage` (String) A comma-separated string or list of key usages
+- `locality` (String) A comma-separated list of the locality that will be set in the issued certificate
+- `metadata` (String) A metadata about the issuer
+- `not_enforce_hostnames` (Boolean) If set, any names are allowed for CN and SANs in the certificate and not only a valid host name
+- `not_require_cn` (Boolean) If set, clients can request certificates without a CN
+- `organizational_units` (String) A comma-separated list of organizational units (OU) that will be set in the issued certificate
+- `organizations` (String) A comma-separated list of organizations (O) that will be set in the issued certificate
+- `postal_code` (String) A comma-separated list of the postal code that will be set in the issued certificate
+- `province` (String) A comma-separated list of the province that will be set in the issued certificate
+- `server_flag` (Boolean) If set, certificates will be flagged for server auth use
+- `street_address` (String) A comma-separated list of the street address that will be set in the issued certificate
+- `tags` (Set of String) List of the tags attached to this key. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_artifactory.md
+++ b/docs/resources/producer_artifactory.md
@@ -17,19 +17,22 @@ Artifactory producer resource
 
 ### Required
 
-- **artifactory_token_audience** (String) A space-separate list of the other Artifactory instances or services that should accept this token., for example: jfrt@*
-- **artifactory_token_scope** (String) Token scope provided as a space-separated list, for example: member-of-groups:readers
-- **name** (String) Producer name
+- `artifactory_token_audience` (String) A space-separate list of the other Artifactory instances or services that should accept this token., for example: jfrt@*
+- `artifactory_token_scope` (String) Token scope provided as a space-separated list, for example: member-of-groups:readers
+- `name` (String) Producer name
 
 ### Optional
 
-- **artifactory_admin_name** (String) Admin name
-- **artifactory_admin_pwd** (String) Admin API Key/Password
-- **base_url** (String) Artifactory REST URL, must end with artifactory postfix
-- **id** (String) The ID of this resource.
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `artifactory_admin_name` (String) Admin name
+- `artifactory_admin_pwd` (String) Admin API Key/Password
+- `base_url` (String) Artifactory REST URL, must end with artifactory postfix
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_aws.md
+++ b/docs/resources/producer_aws.md
@@ -17,31 +17,34 @@ AWS producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **access_mode** (String) The types of credentials to retrieve from AWS. Options:[iam_user,assume_role]
-- **aws_access_key_id** (String) Access Key ID
-- **aws_access_secret_key** (String, Sensitive) Access Secret Key
-- **aws_role_arns** (String) AWS Role ARNs to be use in the Assume Role operation. Multiple values should be separated by comma
-- **aws_user_console_access** (Boolean) Enable AWS User console access
-- **aws_user_groups** (String) UserGroup name(s). Multiple values should be separated by comma
-- **aws_user_policies** (String) Policy ARN(s). Multiple values should be separated by comma
-- **aws_user_programmatic_access** (Boolean) Enable AWS User programmatic access
-- **id** (String) The ID of this resource.
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **region** (String) Region
-- **secure_access_aws_account_id** (String) The aws account id
-- **secure_access_aws_native_cli** (Boolean) The aws native cli
-- **secure_access_aws_region** (String)
-- **secure_access_bastion_issuer** (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_url** (String)
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **secure_access_web_browsing** (Boolean) Secure browser via Akeyless Web Access Bastion
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `access_mode` (String) The types of credentials to retrieve from AWS. Options:[iam_user,assume_role]
+- `aws_access_key_id` (String) Access Key ID
+- `aws_access_secret_key` (String, Sensitive) Access Secret Key
+- `aws_role_arns` (String) AWS Role ARNs to be use in the Assume Role operation. Multiple values should be separated by comma
+- `aws_user_console_access` (Boolean) Enable AWS User console access
+- `aws_user_groups` (String) UserGroup name(s). Multiple values should be separated by comma
+- `aws_user_policies` (String) Policy ARN(s). Multiple values should be separated by comma
+- `aws_user_programmatic_access` (Boolean) Enable AWS User programmatic access
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `region` (String) Region
+- `secure_access_aws_account_id` (String) The aws account id
+- `secure_access_aws_native_cli` (Boolean) The aws native cli
+- `secure_access_aws_region` (String)
+- `secure_access_bastion_issuer` (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_url` (String)
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `secure_access_web_browsing` (Boolean) Secure browser via Akeyless Web Access Bastion
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_azure.md
+++ b/docs/resources/producer_azure.md
@@ -17,27 +17,30 @@ Azure AD producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **app_obj_id** (String) Azure App Object ID (required if selected programmatic access)
-- **azure_client_id** (String) Azure Client ID (Application ID)
-- **azure_client_secret** (String) Azure AD Client Secret
-- **azure_tenant_id** (String) Azure Tenant ID
-- **id** (String) The ID of this resource.
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_url** (String)
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **secure_access_web_browsing** (Boolean) Secure browser via Akeyless Web Access Bastion
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_group_obj_id** (String) Azure AD User Group Object ID (required if selected Portal access)
-- **user_portal_access** (Boolean) Enable Azure AD user portal access
-- **user_principal_name** (String) Azure AD User Principal Name (required if selected Portal access)
-- **user_programmatic_access** (Boolean) Enable Azure AD user programmatic access
-- **user_role_template_id** (String) Azure AD User Role Template ID (required if selected Portal access)
-- **user_ttl** (String) User TTL
+- `app_obj_id` (String) Azure App Object ID (required if selected programmatic access)
+- `azure_client_id` (String) Azure Client ID (Application ID)
+- `azure_client_secret` (String) Azure AD Client Secret
+- `azure_tenant_id` (String) Azure Tenant ID
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_url` (String)
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `secure_access_web_browsing` (Boolean) Secure browser via Akeyless Web Access Bastion
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_group_obj_id` (String) Azure AD User Group Object ID (required if selected Portal access)
+- `user_portal_access` (Boolean) Enable Azure AD user portal access
+- `user_principal_name` (String) Azure AD User Principal Name (required if selected Portal access)
+- `user_programmatic_access` (Boolean) Enable Azure AD user programmatic access
+- `user_role_template_id` (String) Azure AD User Role Template ID (required if selected Portal access)
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_cassandra.md
+++ b/docs/resources/producer_cassandra.md
@@ -17,19 +17,22 @@ Cassandra producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **cassandra_creation_statements** (String) Cassandra Creation Statements
-- **cassandra_hosts** (String) Cassandra hosts names or IP addresses, comma separated
-- **cassandra_password** (String) Cassandra superuser password
-- **cassandra_port** (String) Cassandra port
-- **cassandra_username** (String) Cassandra superuser user name
-- **id** (String) The ID of this resource.
-- **producer_encryption_key_name** (String) Dynamic producer encryption key
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Target name
-- **user_ttl** (String) User TTL (<=60m for access token)
+- `cassandra_creation_statements` (String) Cassandra Creation Statements
+- `cassandra_hosts` (String) Cassandra hosts names or IP addresses, comma separated
+- `cassandra_password` (String) Cassandra superuser password
+- `cassandra_port` (String) Cassandra port
+- `cassandra_username` (String) Cassandra superuser user name
+- `producer_encryption_key_name` (String) Dynamic producer encryption key
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Target name
+- `user_ttl` (String) User TTL (<=60m for access token)
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_custom.md
+++ b/docs/resources/producer_custom.md
@@ -17,20 +17,23 @@ Custom producer resource
 
 ### Required
 
-- **create_sync_url** (String) URL of an endpoint that implements /sync/create method
-- **name** (String) Producer name
-- **revoke_sync_url** (String) URL of an endpoint that implements /sync/revoke method
+- `create_sync_url` (String) URL of an endpoint that implements /sync/create method
+- `name` (String) Producer name
+- `revoke_sync_url` (String) URL of an endpoint that implements /sync/revoke method
 
 ### Optional
 
-- **admin_rotation_interval_days** (Number) Rotation period in days
-- **enable_admin_rotation** (Boolean) Enable automatic admin credentials rotation
-- **id** (String) The ID of this resource.
-- **payload** (String) Secret payload to be sent with each create/revoke webhook request
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **rotate_sync_url** (String) URL of an endpoint that implements /sync/rotate method
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **timeout_sec** (Number) Maximum allowed time in seconds for the webhook to return the results
-- **user_ttl** (String) User TTL
+- `admin_rotation_interval_days` (Number) Rotation period in days
+- `enable_admin_rotation` (Boolean) Enable automatic admin credentials rotation
+- `payload` (String) Secret payload to be sent with each create/revoke webhook request
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `rotate_sync_url` (String) URL of an endpoint that implements /sync/rotate method
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `timeout_sec` (Number) Maximum allowed time in seconds for the webhook to return the results
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_eks.md
+++ b/docs/resources/producer_eks.md
@@ -17,26 +17,29 @@ Amazon Elastic Kubernetes Service (Amazon EKS) producer
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **eks_access_key_id** (String) EKS Access Key ID
-- **eks_assume_role** (String) Role ARN. Role to assume when connecting to the EKS cluster
-- **eks_cluster_ca_cert** (String, Sensitive) EKS Cluster certificate. Base 64 encoded certificate.
-- **eks_cluster_endpoint** (String) EKS Cluster endpoint. https:// , <DNS / IP> of the cluster.
-- **eks_cluster_name** (String) EKS cluster name. Must match the EKS cluster name you want to connect to.
-- **eks_region** (String) EKS Region
-- **eks_secret_access_key** (String, Sensitive) EKS Secret Access Key
-- **id** (String) The ID of this resource.
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **secure_access_allow_port_forwading** (Boolean) Enable Port forwarding while using CLI access.
-- **secure_access_bastion_issuer** (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
-- **secure_access_cluster_endpoint** (String) The K8s cluster endpoint URL
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `eks_access_key_id` (String) EKS Access Key ID
+- `eks_assume_role` (String) Role ARN. Role to assume when connecting to the EKS cluster
+- `eks_cluster_ca_cert` (String, Sensitive) EKS Cluster certificate. Base 64 encoded certificate.
+- `eks_cluster_endpoint` (String) EKS Cluster endpoint. https:// , <DNS / IP> of the cluster.
+- `eks_cluster_name` (String) EKS cluster name. Must match the EKS cluster name you want to connect to.
+- `eks_region` (String) EKS Region
+- `eks_secret_access_key` (String, Sensitive) EKS Secret Access Key
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `secure_access_allow_port_forwading` (Boolean) Enable Port forwarding while using CLI access.
+- `secure_access_bastion_issuer` (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
+- `secure_access_cluster_endpoint` (String) The K8s cluster endpoint URL
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_gcp.md
+++ b/docs/resources/producer_gcp.md
@@ -17,19 +17,22 @@ Google Cloud Provider (GCP)  producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **gcp_cred_type** (String) Credentials type, options are [token, key]
-- **gcp_key** (String) Base64-encoded service account private key text
-- **gcp_key_algo** (String) Service account key algorithm, e.g. KEY_ALG_RSA_1024
-- **gcp_sa_email** (String) GCP service account email
-- **gcp_token_scopes** (String) Access token scopes list, e.g. scope1,scope2
-- **id** (String) The ID of this resource.
-- **producer_encryption_key_name** (String) Dynamic producer encryption key
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL (<=60m for access token)
+- `gcp_cred_type` (String) Credentials type, options are [token, key]
+- `gcp_key` (String) Base64-encoded service account private key text
+- `gcp_key_algo` (String) Service account key algorithm, e.g. KEY_ALG_RSA_1024
+- `gcp_sa_email` (String) GCP service account email
+- `gcp_token_scopes` (String) Access token scopes list, e.g. scope1,scope2
+- `producer_encryption_key_name` (String) Dynamic producer encryption key
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL (<=60m for access token)
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_github.md
+++ b/docs/resources/producer_github.md
@@ -17,18 +17,21 @@ Github producer resource.
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **github_app_id** (Number) Github application id
-- **github_app_private_key** (String) Github application private key (base64 encoded key)
-- **github_base_url** (String) Github base url
-- **id** (String) The ID of this resource.
-- **installation_id** (Number) Github application installation id
-- **installation_repository** (String) Optional, instead of installation id, set a GitHub repository '<owner>/<repo-name>'
-- **target_name** (String) Name of existing target to use in producer creation
-- **token_permissions** (Set of String) Tokens' allowed permissions. By default use installation allowed permissions. Input format: key=value pairs or JSON strings, e.g - -p contents=read -p issues=write or -p '{content:read}'
-- **token_repositories** (Set of String) Tokens' allowed repositories. By default use installation allowed repositories. To specify multiple repositories use argument multiple times: -r RepoName1 -r RepoName2
+- `github_app_id` (Number) Github application id
+- `github_app_private_key` (String) Github application private key (base64 encoded key)
+- `github_base_url` (String) Github base url
+- `installation_id` (Number) Github application installation id
+- `installation_repository` (String) Optional, instead of installation id, set a GitHub repository '<owner>/<repo-name>'
+- `target_name` (String) Name of existing target to use in producer creation
+- `token_permissions` (Set of String) Tokens' allowed permissions. By default use installation allowed permissions. Input format: key=value pairs or JSON strings, e.g - -p contents=read -p issues=write or -p '{content:read}'
+- `token_repositories` (Set of String) Tokens' allowed repositories. By default use installation allowed repositories. To specify multiple repositories use argument multiple times: -r RepoName1 -r RepoName2
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_gke.md
+++ b/docs/resources/producer_gke.md
@@ -17,24 +17,27 @@ Google Kubernetes Engine (GKE) producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **gke_account_key** (String) GKE service account key
-- **gke_cluster_cert** (String) GKE Base-64 encoded cluster certificate
-- **gke_cluster_endpoint** (String) GKE cluster endpoint, i.e., cluster URI https://<DNS/IP>.
-- **gke_cluster_name** (String) GKE cluster name
-- **gke_service_account_email** (String) GKE service account email
-- **id** (String) The ID of this resource.
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **secure_access_allow_port_forwading** (Boolean) Enable Port forwarding while using CLI access.
-- **secure_access_bastion_issuer** (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
-- **secure_access_cluster_endpoint** (String) The K8s cluster endpoint URL
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `gke_account_key` (String) GKE service account key
+- `gke_cluster_cert` (String) GKE Base-64 encoded cluster certificate
+- `gke_cluster_endpoint` (String) GKE cluster endpoint, i.e., cluster URI https://<DNS/IP>.
+- `gke_cluster_name` (String) GKE cluster name
+- `gke_service_account_email` (String) GKE service account email
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `secure_access_allow_port_forwading` (Boolean) Enable Port forwarding while using CLI access.
+- `secure_access_bastion_issuer` (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
+- `secure_access_cluster_endpoint` (String) The K8s cluster endpoint URL
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_k8s.md
+++ b/docs/resources/producer_k8s.md
@@ -17,26 +17,29 @@ Native Kubernetes Service producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **k8s_cluster_ca_cert** (String, Sensitive) K8S Cluster certificate. Base 64 encoded certificate.
-- **k8s_cluster_endpoint** (String) K8S Cluster endpoint. https:// , <DNS / IP> of the cluster.
-- **k8s_cluster_token** (String) K8S Cluster authentication token.
-- **k8s_namespace** (String) K8S Namespace where the ServiceAccount exists.
-- **k8s_service_account** (String) K8S ServiceAccount to extract token from.
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **secure_access_allow_port_forwading** (Boolean) Enable Port forwarding while using CLI access.
-- **secure_access_bastion_issuer** (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
-- **secure_access_cluster_endpoint** (String) The K8s cluster endpoint
-- **secure_access_dashboard_url** (String) The K8s dashboard url
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **secure_access_web_browsing** (Boolean) Secure browser via Akeyless Web Access Bastion
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `k8s_cluster_ca_cert` (String, Sensitive) K8S Cluster certificate. Base 64 encoded certificate.
+- `k8s_cluster_endpoint` (String) K8S Cluster endpoint. https:// , <DNS / IP> of the cluster.
+- `k8s_cluster_token` (String) K8S Cluster authentication token.
+- `k8s_namespace` (String) K8S Namespace where the ServiceAccount exists.
+- `k8s_service_account` (String) K8S ServiceAccount to extract token from.
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `secure_access_allow_port_forwading` (Boolean) Enable Port forwarding while using CLI access.
+- `secure_access_bastion_issuer` (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
+- `secure_access_cluster_endpoint` (String) The K8s cluster endpoint
+- `secure_access_dashboard_url` (String) The K8s dashboard url
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `secure_access_web_browsing` (Boolean) Secure browser via Akeyless Web Access Bastion
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_mongo.md
+++ b/docs/resources/producer_mongo.md
@@ -17,30 +17,33 @@ Mongo DB Producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **mongodb_atlas_api_private_key** (String) MongoDB Atlas private key
-- **mongodb_atlas_api_public_key** (String) MongoDB Atlas public key
-- **mongodb_atlas_project_id** (String) MongoDB Atlas project ID
-- **mongodb_default_auth_db** (String) MongoDB server default authentication database
-- **mongodb_host_port** (String) host:port (e.g. my.mongo.db:27017)
-- **mongodb_name** (String) MongoDB name
-- **mongodb_password** (String) MongoDB server password
-- **mongodb_roles** (String) MongoDB roles (e.g. MongoDB:[{role:readWrite, db: sales}], MongoDB Atlas:[{roleName : readWrite, databaseName: sales}])
-- **mongodb_server_uri** (String) MongoDB server URI (e.g. mongodb://user:password@my.mongo.db:27017/admin?replicaSet=mySet)
-- **mongodb_uri_options** (String) MongoDB server URI options (e.g. replicaSet=mySet&authSource=authDB)
-- **mongodb_username** (String) MongoDB server username
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **secure_access_bastion_issuer** (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
-- **secure_access_db_name** (String) Enable Web Secure Remote Access
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_host** (Set of String) Target DB servers for connections., For multiple values repeat this flag.
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL (e.g. 60s, 60m, 60h)
+- `mongodb_atlas_api_private_key` (String) MongoDB Atlas private key
+- `mongodb_atlas_api_public_key` (String) MongoDB Atlas public key
+- `mongodb_atlas_project_id` (String) MongoDB Atlas project ID
+- `mongodb_default_auth_db` (String) MongoDB server default authentication database
+- `mongodb_host_port` (String) host:port (e.g. my.mongo.db:27017)
+- `mongodb_name` (String) MongoDB name
+- `mongodb_password` (String) MongoDB server password
+- `mongodb_roles` (String) MongoDB roles (e.g. MongoDB:[{role:readWrite, db: sales}], MongoDB Atlas:[{roleName : readWrite, databaseName: sales}])
+- `mongodb_server_uri` (String) MongoDB server URI (e.g. mongodb://user:password@my.mongo.db:27017/admin?replicaSet=mySet)
+- `mongodb_uri_options` (String) MongoDB server URI options (e.g. replicaSet=mySet&authSource=authDB)
+- `mongodb_username` (String) MongoDB server username
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `secure_access_bastion_issuer` (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
+- `secure_access_db_name` (String) Enable Web Secure Remote Access
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_host` (Set of String) Target DB servers for connections., For multiple values repeat this flag.
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL (e.g. 60s, 60m, 60h)
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_mssql.md
+++ b/docs/resources/producer_mssql.md
@@ -17,27 +17,30 @@ Microsoft SQL Server producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **mssql_create_statements** (String) MSSQL Server Creation Statements
-- **mssql_dbname** (String) MSSQL Server DB Name
-- **mssql_host** (String) MS SQL Server host name
-- **mssql_password** (String) MS SQL Server password
-- **mssql_port** (String) MS SQL Server port
-- **mssql_revocation_statements** (String) MSSQL Server Revocation Statements
-- **mssql_username** (String) MS SQL Server user
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **secure_access_bastion_issuer** (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
-- **secure_access_db_name** (String) Enable Web Secure Remote Access
-- **secure_access_db_schema** (String) The db schema
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_host** (Set of String) Target DB servers for connections., For multiple values repeat this flag.
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `mssql_create_statements` (String) MSSQL Server Creation Statements
+- `mssql_dbname` (String) MSSQL Server DB Name
+- `mssql_host` (String) MS SQL Server host name
+- `mssql_password` (String) MS SQL Server password
+- `mssql_port` (String) MS SQL Server port
+- `mssql_revocation_statements` (String) MSSQL Server Revocation Statements
+- `mssql_username` (String) MS SQL Server user
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `secure_access_bastion_issuer` (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
+- `secure_access_db_name` (String) Enable Web Secure Remote Access
+- `secure_access_db_schema` (String) The db schema
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_host` (Set of String) Target DB servers for connections., For multiple values repeat this flag.
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_mysql.md
+++ b/docs/resources/producer_mysql.md
@@ -17,27 +17,30 @@ MySQL producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **db_server_certificates** (String) the set of root certificate authorities in base64 encoding that clients use when verifying server certificates
-- **db_server_name** (String) Server name is used to verify the hostname on the returned certificates unless InsecureSkipVerify is given. It is also included in the client's handshake to support virtual hosting unless it is an IP address
-- **id** (String) The ID of this resource.
-- **mysql_dbname** (String) MySQL DB name
-- **mysql_host** (String) MySQL host name
-- **mysql_password** (String, Sensitive) MySQL password
-- **mysql_port** (String) MySQL port
-- **mysql_screation_statements** (String) MySQL Creation Statements
-- **mysql_username** (String) MySQL user
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **secure_access_bastion_issuer** (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
-- **secure_access_db_name** (String) Enable Web Secure Remote Access
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_host** (Set of String) Target DB servers for connections., For multiple values repeat this flag.
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `db_server_certificates` (String) the set of root certificate authorities in base64 encoding that clients use when verifying server certificates
+- `db_server_name` (String) Server name is used to verify the hostname on the returned certificates unless InsecureSkipVerify is given. It is also included in the client's handshake to support virtual hosting unless it is an IP address
+- `mysql_dbname` (String) MySQL DB name
+- `mysql_host` (String) MySQL host name
+- `mysql_password` (String, Sensitive) MySQL password
+- `mysql_port` (String) MySQL port
+- `mysql_screation_statements` (String) MySQL Creation Statements
+- `mysql_username` (String) MySQL user
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `secure_access_bastion_issuer` (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
+- `secure_access_db_name` (String) Enable Web Secure Remote Access
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_host` (Set of String) Target DB servers for connections., For multiple values repeat this flag.
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_oracle.md
+++ b/docs/resources/producer_oracle.md
@@ -17,22 +17,25 @@ Oracle DB producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **db_server_certificates** (String) the set of root certificate authorities in base64 encoding that clients use when verifying server certificates
-- **db_server_name** (String) Server name is used to verify the hostname on the returned certificates unless InsecureSkipVerify is given. It is also included in the client's handshake to support virtual hosting unless it is an IP address
-- **id** (String) The ID of this resource.
-- **oracle_host** (String) Oracle host name
-- **oracle_password** (String) Oracle password
-- **oracle_port** (String) Oracle port
-- **oracle_screation_statements** (String) Oracle Creation Statements
-- **oracle_service_name** (String) Oracle service name
-- **oracle_username** (String) Oracle user
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `db_server_certificates` (String) the set of root certificate authorities in base64 encoding that clients use when verifying server certificates
+- `db_server_name` (String) Server name is used to verify the hostname on the returned certificates unless InsecureSkipVerify is given. It is also included in the client's handshake to support virtual hosting unless it is an IP address
+- `oracle_host` (String) Oracle host name
+- `oracle_password` (String) Oracle password
+- `oracle_port` (String) Oracle port
+- `oracle_screation_statements` (String) Oracle Creation Statements
+- `oracle_service_name` (String) Oracle service name
+- `oracle_username` (String) Oracle user
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_postgres.md
+++ b/docs/resources/producer_postgres.md
@@ -17,26 +17,29 @@ PostgreSQLproducer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **creation_statements** (String) PostgreSQL Creation Statements
-- **id** (String) The ID of this resource.
-- **postgresql_db_name** (String) PostgreSQL DB name
-- **postgresql_host** (String) PostgreSQL host name
-- **postgresql_password** (String) PostgreSQL password
-- **postgresql_port** (String) PostgreSQL port
-- **postgresql_username** (String) PostgreSQL user
-- **producer_encryption_key** (String) Encrypt producer with following key
-- **secure_access_bastion_issuer** (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
-- **secure_access_db_name** (String) Enable Web Secure Remote Access
-- **secure_access_db_schema** (String) The db schema
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_host** (Set of String) Target DB servers for connections., For multiple values repeat this flag.
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `creation_statements` (String) PostgreSQL Creation Statements
+- `postgresql_db_name` (String) PostgreSQL DB name
+- `postgresql_host` (String) PostgreSQL host name
+- `postgresql_password` (String) PostgreSQL password
+- `postgresql_port` (String) PostgreSQL port
+- `postgresql_username` (String) PostgreSQL user
+- `producer_encryption_key` (String) Encrypt producer with following key
+- `secure_access_bastion_issuer` (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
+- `secure_access_db_name` (String) Enable Web Secure Remote Access
+- `secure_access_db_schema` (String) The db schema
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_host` (Set of String) Target DB servers for connections., For multiple values repeat this flag.
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_rdp.md
+++ b/docs/resources/producer_rdp.md
@@ -17,26 +17,29 @@ RDP Producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **fixed_user_only** (String) Enable fixed user only
-- **id** (String) The ID of this resource.
-- **producer_encryption_key_name** (String) Encrypt producer with following key
-- **rdp_admin_name** (String) RDP Admin name
-- **rdp_admin_pwd** (String) RDP Admin Password
-- **rdp_host_name** (String) RDP Host name
-- **rdp_host_port** (String) RDP Host port
-- **rdp_user_groups** (String) RDP UserGroup name(s). Multiple values should be separated by comma
-- **secure_access_allow_external_user** (Boolean) Allow providing external user for a domain users
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_host** (Set of String) Target servers for connections., For multiple values repeat this flag.
-- **secure_access_rdp_domain** (String) Required when the Dynamic Secret is used for a domain user
-- **secure_access_rdp_user** (String) Override the RDP Domain username
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `fixed_user_only` (String) Enable fixed user only
+- `producer_encryption_key_name` (String) Encrypt producer with following key
+- `rdp_admin_name` (String) RDP Admin name
+- `rdp_admin_pwd` (String) RDP Admin Password
+- `rdp_host_name` (String) RDP Host name
+- `rdp_host_port` (String) RDP Host port
+- `rdp_user_groups` (String) RDP UserGroup name(s). Multiple values should be separated by comma
+- `secure_access_allow_external_user` (Boolean) Allow providing external user for a domain users
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_host` (Set of String) Target servers for connections., For multiple values repeat this flag.
+- `secure_access_rdp_domain` (String) Required when the Dynamic Secret is used for a domain user
+- `secure_access_rdp_user` (String) Override the RDP Domain username
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/producer_redshift.md
+++ b/docs/resources/producer_redshift.md
@@ -17,24 +17,27 @@ Redshift producer resource
 
 ### Required
 
-- **name** (String) Producer name
+- `name` (String) Producer name
 
 ### Optional
 
-- **creation_statements** (String) Redshift Creation Statements
-- **id** (String) The ID of this resource.
-- **producer_encryption_key** (String) Encrypt producer with following key
-- **redshift_db_name** (String) Redshift DB name
-- **redshift_host** (String) Redshift host name
-- **redshift_password** (String) Redshift password
-- **redshift_port** (String) Redshift port
-- **redshift_username** (String) redshiftL user
-- **secure_access_db_name** (String) Enable Web Secure Remote Access
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_host** (Set of String) Target DB servers for connections., For multiple values repeat this flag.
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **target_name** (String) Name of existing target to use in producer creation
-- **user_ttl** (String) User TTL
+- `creation_statements` (String) Redshift Creation Statements
+- `producer_encryption_key` (String) Encrypt producer with following key
+- `redshift_db_name` (String) Redshift DB name
+- `redshift_host` (String) Redshift host name
+- `redshift_password` (String) Redshift password
+- `redshift_port` (String) Redshift port
+- `redshift_username` (String) redshiftL user
+- `secure_access_db_name` (String) Enable Web Secure Remote Access
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_host` (Set of String) Target DB servers for connections., For multiple values repeat this flag.
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `target_name` (String) Name of existing target to use in producer creation
+- `user_ttl` (String) User TTL
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -71,30 +71,33 @@ output "demo-role" {
 
 ### Required
 
-- **name** (String) Role name
+- `name` (String) Role name
 
 ### Optional
 
-- **analytics_access** (String) Allow this role to view analytics. Currently only 'none', 'own' and 'all' values are supported, allowing associated auth methods to view reports produced by the same auth methods.
-- **assoc_auth_method** (Block List, Deprecated) Create an association between role and auth method (see [below for nested schema](#nestedblock--assoc_auth_method))
-- **audit_access** (String) Allow this role to view audit logs. Currently only 'none', 'own' and 'all' values are supported, allowing associated auth methods to view audit logs produced by the same auth methods.
-- **comment** (String) Comment about the role
-- **gw_analytics_access** (String) Allow this role to view gw analytics. Currently only 'none', 'own' and 'all' values are supported, allowing associated auth methods to view reports produced by the same auth methods.
-- **id** (String) The ID of this resource.
-- **rules** (Block List) Set a rule to a role (see [below for nested schema](#nestedblock--rules))
-- **sra_reports_access** (String) Allow this role to view SRA Clusters. Currently only 'none', 'own' and 'all' values are supported.
+- `analytics_access` (String) Allow this role to view analytics. Currently only 'none', 'own' and 'all' values are supported, allowing associated auth methods to view reports produced by the same auth methods.
+- `assoc_auth_method` (Block List) Create an association between role and auth method (see [below for nested schema](#nestedblock--assoc_auth_method))
+- `audit_access` (String) Allow this role to view audit logs. Currently only 'none', 'own' and 'all' values are supported, allowing associated auth methods to view audit logs produced by the same auth methods.
+- `comment` (String) Comment about the role
+- `gw_analytics_access` (String) Allow this role to view gw analytics. Currently only 'none', 'own' and 'all' values are supported, allowing associated auth methods to view reports produced by the same auth methods.
+- `rules` (Block List) Set a rule to a role (see [below for nested schema](#nestedblock--rules))
+- `sra_reports_access` (String) Allow this role to view SRA Clusters. Currently only 'none', 'own' and 'all' values are supported.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 <a id="nestedblock--assoc_auth_method"></a>
 ### Nested Schema for `assoc_auth_method`
 
 Required:
 
-- **am_name** (String) The auth method to associate
+- `am_name` (String) The auth method to associate
 
 Optional:
 
-- **case_sensitive** (String) Treat sub claims as case-sensitive
-- **sub_claims** (Map of String) key/val of sub claims, e.g group=admins,developers
+- `case_sensitive` (String) Treat sub claims as case-sensitive
+- `sub_claims` (Map of String) key/val of sub claims, e.g group=admins,developers
 
 
 <a id="nestedblock--rules"></a>
@@ -102,11 +105,11 @@ Optional:
 
 Required:
 
-- **capability** (Set of String) List of the approved/denied capabilities in the path options: [read, create, update, delete, list, deny]
-- **path** (String) The path the rule refers to
+- `capability` (Set of String) List of the approved/denied capabilities in the path options: [read, create, update, delete, list, deny]
+- `path` (String) The path the rule refers to
 
 Optional:
 
-- **rule_type** (String) item-rule, target-rule, role-rule, auth-method-rule
+- `rule_type` (String) item-rule, target-rule, role-rule, auth-method-rule
 
 

--- a/docs/resources/rotated_secret.md
+++ b/docs/resources/rotated_secret.md
@@ -17,27 +17,30 @@ Rotated secret resource
 
 ### Required
 
-- **name** (String) Secret name
-- **rotator_type** (String) The rotator type password/target/api-key/ldap/custom
-- **target_name** (String) The target name to associate
+- `name` (String) Secret name
+- `rotator_type` (String) The rotator type password/target/api-key/ldap/custom
+- `target_name` (String) The target name to associate
 
 ### Optional
 
-- **api_id** (String) API ID to rotate (relevant only for rotator-type=api-key)
-- **api_key** (String) API key to rotate (relevant only for rotator-type=api-key)
-- **authentication_credentials** (String) The credentials to connect with use-user-creds/use-target-creds
-- **auto_rotate** (String) Whether to automatically rotate every --rotation-interval days, or disable existing automatic rotation
-- **custom_payload** (String) Secret payload to be sent with rotation request (relevant only for rotator-type=custom)
-- **id** (String) The ID of this resource.
-- **key** (String) The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)
-- **metadata** (String) Metadata about the secret
-- **rotated_password** (String) rotated-username password (relevant only for rotator-type=password)
-- **rotated_username** (String) username to be rotated, if selected use-self-creds at rotator-creds-type, this username will try to rotate it's own password, if use-target-creds is selected, target credentials will be use to rotate the rotated-password (relevant only for rotator-type=password)
-- **rotation_hour** (Number) The Hour of the rotation in UTC
-- **rotation_interval** (String) The number of days to wait between every automatic rotation (1-365),custom rotator interval will be set in minutes
-- **rotator_custom_cmd** (String) Custom rotation command (relevant only for ssh target)
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
-- **user_attribute** (String) LDAP User Attribute
-- **user_dn** (String) Base DN to Perform User Search
+- `api_id` (String) API ID to rotate (relevant only for rotator-type=api-key)
+- `api_key` (String) API key to rotate (relevant only for rotator-type=api-key)
+- `authentication_credentials` (String) The credentials to connect with use-user-creds/use-target-creds
+- `auto_rotate` (String) Whether to automatically rotate every --rotation-interval days, or disable existing automatic rotation
+- `custom_payload` (String) Secret payload to be sent with rotation request (relevant only for rotator-type=custom)
+- `key` (String) The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)
+- `metadata` (String) Metadata about the secret
+- `rotated_password` (String) rotated-username password (relevant only for rotator-type=password)
+- `rotated_username` (String) username to be rotated, if selected use-self-creds at rotator-creds-type, this username will try to rotate it's own password, if use-target-creds is selected, target credentials will be use to rotate the rotated-password (relevant only for rotator-type=password)
+- `rotation_hour` (Number) The Hour of the rotation in UTC
+- `rotation_interval` (String) The number of days to wait between every automatic rotation (1-365),custom rotator interval will be set in minutes
+- `rotator_custom_cmd` (String) Custom rotation command (relevant only for ssh target)
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `user_attribute` (String) LDAP User Attribute
+- `user_dn` (String) Base DN to Perform User Search
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/ssh_cert_issuer.md
+++ b/docs/resources/ssh_cert_issuer.md
@@ -17,23 +17,26 @@ SSH Cert Issuer  resource
 
 ### Required
 
-- **allowed_users** (String) Users allowed to fetch the certificate, e.g root,ubuntu
-- **name** (String) SSH certificate issuer name
-- **signer_key_name** (String) A key to sign the certificate with
-- **ttl** (Number) he requested Time To Live for the certificate, in seconds
+- `allowed_users` (String) Users allowed to fetch the certificate, e.g root,ubuntu
+- `name` (String) SSH certificate issuer name
+- `signer_key_name` (String) A key to sign the certificate with
+- `ttl` (Number) he requested Time To Live for the certificate, in seconds
 
 ### Optional
 
-- **extensions** (Map of String) Signed certificates with extensions (key/val), e.g permit-port-forwarding=
-- **id** (String) The ID of this resource.
-- **metadata** (String) A metadata about the issuer
-- **principals** (String) Signed certificates with principal, e.g example_role1,example_role2
-- **secure_access_bastion_api** (String) Bastion's SSH control API endpoint. E.g. https://my.bastion:9900
-- **secure_access_bastion_ssh** (String) Bastion's SSH server. E.g. my.bastion:22
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_host** (Set of String) Target servers for connections., For multiple values repeat this flag.
-- **secure_access_ssh_creds_user** (String) SSH username to connect to target server, must be in 'Allowed Users' list
-- **secure_access_use_internal_bastion** (Boolean) Use internal SSH Bastion
-- **tags** (Set of String) List of the tags attached to this key. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
+- `extensions` (Map of String) Signed certificates with extensions (key/val), e.g permit-port-forwarding=
+- `metadata` (String) A metadata about the issuer
+- `principals` (String) Signed certificates with principal, e.g example_role1,example_role2
+- `secure_access_bastion_api` (String) Bastion's SSH control API endpoint. E.g. https://my.bastion:9900
+- `secure_access_bastion_ssh` (String) Bastion's SSH server. E.g. my.bastion:22
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_host` (Set of String) Target servers for connections., For multiple values repeat this flag.
+- `secure_access_ssh_creds_user` (String) SSH username to connect to target server, must be in 'Allowed Users' list
+- `secure_access_use_internal_bastion` (Boolean) Use internal SSH Bastion
+- `tags` (Set of String) List of the tags attached to this key. To specify multiple tags use argument multiple times: --tag Tag1 --tag Tag2
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/static_secret.md
+++ b/docs/resources/static_secret.md
@@ -41,28 +41,28 @@ resource "akeyless_static_secret" "secret" {
 
 ### Required
 
-- **path** (String) The path where the secret will be stored.
-- **value** (String, Sensitive) The secret content.
+- `path` (String) The path where the secret will be stored.
+- `value` (String, Sensitive) The secret content.
 
 ### Optional
 
-- **id** (String) The ID of this resource.
-- **metadata** (String) Metadata about the secret
-- **multiline_value** (Boolean) The provided value is a multiline value (separated by '
+- `metadata` (String) Metadata about the secret
+- `multiline_value` (Boolean) The provided value is a multiline value (separated by '
 ')
-- **protection_key** (String) The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)
-- **secure_access_bastion_issuer** (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
-- **secure_access_enable** (String) Enable/Disable secure remote access, [true/false]
-- **secure_access_host** (Set of String) Target servers for connections., For multiple values repeat this flag.
-- **secure_access_ssh_creds** (String) Static-Secret values contains SSH Credentials, either Private Key or Password [password/private-key]
-- **secure_access_ssh_user** (String) Override the SSH username as indicated in SSH Certificate Issuer
-- **secure_access_url** (String) Destination URL to inject secrets.
-- **secure_access_web** (Boolean) Enable Web Secure Remote Access
-- **secure_access_web_browsing** (Boolean) Secure browser via Akeyless Web Access Bastion
-- **tags** (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
+- `protection_key` (String) The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)
+- `secure_access_bastion_issuer` (String) Path to the SSH Certificate Issuer for your Akeyless Bastion
+- `secure_access_enable` (String) Enable/Disable secure remote access, [true/false]
+- `secure_access_host` (Set of String) Target servers for connections., For multiple values repeat this flag.
+- `secure_access_ssh_creds` (String) Static-Secret values contains SSH Credentials, either Private Key or Password [password/private-key]
+- `secure_access_ssh_user` (String) Override the SSH username as indicated in SSH Certificate Issuer
+- `secure_access_url` (String) Destination URL to inject secrets.
+- `secure_access_web` (Boolean) Enable Web Secure Remote Access
+- `secure_access_web_browsing` (Boolean) Secure browser via Akeyless Web Access Bastion
+- `tags` (Set of String) List of the tags attached to this secret. To specify multiple tags use argument multiple times: -t Tag1 -t Tag2
 
 ### Read-Only
 
-- **version** (Number) The version of the secret.
+- `id` (String) The ID of this resource.
+- `version` (Number) The version of the secret.
 
 

--- a/docs/resources/target_artifactory.md
+++ b/docs/resources/target_artifactory.md
@@ -17,15 +17,18 @@ Artifactory Target resource
 
 ### Required
 
-- **artifactory_admin_name** (String) Admin name
-- **artifactory_admin_pwd** (String) Admin API Key/Password
-- **base_url** (String) Artifactory REST URL, must end with artifactory postfix
-- **name** (String) Target name
+- `artifactory_admin_name` (String) Admin name
+- `artifactory_admin_pwd` (String) Admin API Key/Password
+- `base_url` (String) Artifactory REST URL, must end with artifactory postfix
+- `name` (String) Target name
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **id** (String) The ID of this resource.
-- **key** (String) The name of a key that used to encrypt the target secret value (if empty, the account default protectionKey key will be used)
+- `comment` (String) Comment about the target
+- `key` (String) The name of a key that used to encrypt the target secret value (if empty, the account default protectionKey key will be used)
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_aws.md
+++ b/docs/resources/target_aws.md
@@ -17,17 +17,20 @@ AWS Target resource
 
 ### Required
 
-- **access_key_id** (String) AWS access key ID
-- **name** (String) Target name
+- `access_key_id` (String) AWS access key ID
+- `name` (String) Target name
 
 ### Optional
 
-- **access_key** (String) AWS secret access key
-- **comment** (String) Comment about the target
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
-- **region** (String) AWS region
-- **session_token** (String) Required only for temporary security credentials retrieved using STS
-- **use_gw_cloud_identity** (Boolean) Use the GW's Cloud IAM
+- `access_key` (String) AWS secret access key
+- `comment` (String) Comment about the target
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
+- `region` (String) AWS region
+- `session_token` (String) Required only for temporary security credentials retrieved using STS
+- `use_gw_cloud_identity` (Boolean) Use the GW's Cloud IAM
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_azure.md
+++ b/docs/resources/target_azure.md
@@ -17,16 +17,19 @@ Azure Target resource
 
 ### Required
 
-- **name** (String) Target name
+- `name` (String) Target name
 
 ### Optional
 
-- **client_id** (String) Azure client/application id
-- **client_secret** (String) Azure client secret
-- **comment** (String) Comment about the target
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key is used to encrypt the target secret value. If the key name is not specified, the account default protection key is used
-- **tenant_id** (String) Azure tenant id
-- **use_gw_cloud_identity** (Boolean) Use the GW's Cloud IAM
+- `client_id` (String) Azure client/application id
+- `client_secret` (String) Azure client secret
+- `comment` (String) Comment about the target
+- `key` (String) Key name. The key is used to encrypt the target secret value. If the key name is not specified, the account default protection key is used
+- `tenant_id` (String) Azure tenant id
+- `use_gw_cloud_identity` (Boolean) Use the GW's Cloud IAM
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_db.md
+++ b/docs/resources/target_db.md
@@ -17,28 +17,31 @@ DB Target resource
 
 ### Required
 
-- **db_type** (String) Database type: mysql/mssql/postgres/mongodb/snowflake/oracle/cassandra/redshift
-- **name** (String) Target name
+- `db_type` (String) Database type: mysql/mssql/postgres/mongodb/snowflake/oracle/cassandra/redshift
+- `name` (String) Target name
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **db_name** (String) Database name
-- **db_server_certificates** (String) Set of root certificate authorities in base64 encoding used by clients to verify server certificates
-- **db_server_name** (String) Server name is used to verify the hostname on the returned certificates unless InsecureSkipVerify is provided. It is also included in the client's handshake to support virtual hosting unless it is an IP address
-- **host** (String) Database host
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
-- **mongodb_atlas** (Boolean) Flag, set database type to mongodb and the flag to true to create Mongo Atlas target
-- **mongodb_atlas_api_private_key** (String) MongoDB Atlas private key
-- **mongodb_atlas_api_public_key** (String) MongoDB Atlas public key
-- **mongodb_atlas_project_id** (String) MongoDB Atlas project ID
-- **mongodb_default_auth_db** (String) MongoDB server default authentication database
-- **mongodb_uri_options** (String) MongoDB server URI options (e.g. replicaSet=mySet&authSource=authDB)
-- **oracle_service_name** (String) oracle db service name
-- **port** (String) Database port
-- **pwd** (String) Database password
-- **snowflake_account** (String) Snowflake account name
-- **user_name** (String) Database user name
+- `comment` (String) Comment about the target
+- `db_name` (String) Database name
+- `db_server_certificates` (String) Set of root certificate authorities in base64 encoding used by clients to verify server certificates
+- `db_server_name` (String) Server name is used to verify the hostname on the returned certificates unless InsecureSkipVerify is provided. It is also included in the client's handshake to support virtual hosting unless it is an IP address
+- `host` (String) Database host
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
+- `mongodb_atlas` (Boolean) Flag, set database type to mongodb and the flag to true to create Mongo Atlas target
+- `mongodb_atlas_api_private_key` (String) MongoDB Atlas private key
+- `mongodb_atlas_api_public_key` (String) MongoDB Atlas public key
+- `mongodb_atlas_project_id` (String) MongoDB Atlas project ID
+- `mongodb_default_auth_db` (String) MongoDB server default authentication database
+- `mongodb_uri_options` (String) MongoDB server URI options (e.g. replicaSet=mySet&authSource=authDB)
+- `oracle_service_name` (String) oracle db service name
+- `port` (String) Database port
+- `pwd` (String) Database password
+- `snowflake_account` (String) Snowflake account name
+- `user_name` (String) Database user name
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_eks.md
+++ b/docs/resources/target_eks.md
@@ -17,19 +17,22 @@ EKS Target resource
 
 ### Required
 
-- **eks_access_key_id** (String) EKS access key ID
-- **eks_cluster_ca_cert** (String, Sensitive) EKS cluster base-64 encoded certificate
-- **eks_cluster_endpoint** (String) EKS cluster endpoint (i.e., https://<IP> of the cluster)
-- **eks_cluster_name** (String) EKS cluster name
-- **eks_secret_access_key** (String, Sensitive) EKS secret access key
-- **name** (String) Target name
+- `eks_access_key_id` (String) EKS access key ID
+- `eks_cluster_ca_cert` (String, Sensitive) EKS cluster base-64 encoded certificate
+- `eks_cluster_endpoint` (String) EKS cluster endpoint (i.e., https://<IP> of the cluster)
+- `eks_cluster_name` (String) EKS cluster name
+- `eks_secret_access_key` (String, Sensitive) EKS secret access key
+- `name` (String) Target name
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **eks_region** (String) EKS region
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used.
-- **use_gw_cloud_identity** (Boolean) Use the GW's Cloud IAM
+- `comment` (String) Comment about the target
+- `eks_region` (String) EKS region
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used.
+- `use_gw_cloud_identity` (Boolean) Use the GW's Cloud IAM
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_gcp.md
+++ b/docs/resources/target_gcp.md
@@ -17,15 +17,18 @@ GCP Target resource
 
 ### Required
 
-- **name** (String) Target name
+- `name` (String) Target name
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **gcp_key** (String) Base64-encoded service account private key text
-- **gcp_sa_email** (String) GCP service account email
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
-- **use_gw_cloud_identity** (Boolean) Use the GW's Cloud IAM
+- `comment` (String) Comment about the target
+- `gcp_key` (String) Base64-encoded service account private key text
+- `gcp_sa_email` (String) GCP service account email
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
+- `use_gw_cloud_identity` (Boolean) Use the GW's Cloud IAM
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_github.md
+++ b/docs/resources/target_github.md
@@ -17,15 +17,18 @@ Github Target resource
 
 ### Required
 
-- **name** (String) Target name
+- `name` (String) Target name
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **github_app_id** (Number) Github application id
-- **github_app_private_key** (String) Github application private key (base64 encoded key)
-- **github_base_url** (String) Github base url
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used.
+- `comment` (String) Comment about the target
+- `github_app_id` (Number) Github application id
+- `github_app_private_key` (String) Github application private key (base64 encoded key)
+- `github_base_url` (String) Github base url
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_gke.md
+++ b/docs/resources/target_gke.md
@@ -17,18 +17,21 @@ GKE Target resource
 
 ### Required
 
-- **name** (String) Target name
+- `name` (String) Target name
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **gke_account_key** (String) GKE service account key
-- **gke_cluster_cert** (String) GKE Base-64 encoded cluster certificate
-- **gke_cluster_endpoint** (String) GKE cluster endpoint, i.e., cluster URI https://<DNS/IP>.
-- **gke_cluster_name** (String) GKE cluster name
-- **gke_service_account_email** (String) GKE service account email
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
-- **use_gw_cloud_identity** (Boolean) Use the GW's Cloud IAM
+- `comment` (String) Comment about the target
+- `gke_account_key` (String) GKE service account key
+- `gke_cluster_cert` (String) GKE Base-64 encoded cluster certificate
+- `gke_cluster_endpoint` (String) GKE cluster endpoint, i.e., cluster URI https://<DNS/IP>.
+- `gke_cluster_name` (String) GKE cluster name
+- `gke_service_account_email` (String) GKE service account email
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
+- `use_gw_cloud_identity` (Boolean) Use the GW's Cloud IAM
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_k8s.md
+++ b/docs/resources/target_k8s.md
@@ -17,15 +17,18 @@ K8S Target resource
 
 ### Required
 
-- **k8s_cluster_ca_cert** (String, Sensitive) K8S Cluster certificate. Base 64 encoded certificate.
-- **k8s_cluster_endpoint** (String) K8S Cluster endpoint. https:// , <DNS / IP> of the cluster.
-- **k8s_cluster_token** (String) K8S Cluster authentication token.
-- **name** (String) Target name
+- `k8s_cluster_ca_cert` (String, Sensitive) K8S Cluster certificate. Base 64 encoded certificate.
+- `k8s_cluster_endpoint` (String) K8S Cluster endpoint. https:// , <DNS / IP> of the cluster.
+- `k8s_cluster_token` (String) K8S Cluster authentication token.
+- `name` (String) Target name
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used.
+- `comment` (String) Comment about the target
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_rabbit.md
+++ b/docs/resources/target_rabbit.md
@@ -17,15 +17,18 @@ RabbitMQT Target resource
 
 ### Required
 
-- **name** (String) Target name
-- **rabbitmq_server_uri** (String) RabbitMQ server URI
-- **rabbitmq_server_user** (String) RabbitMQ server user
+- `name` (String) Target name
+- `rabbitmq_server_uri` (String) RabbitMQ server URI
+- `rabbitmq_server_user` (String) RabbitMQ server user
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
-- **rabbitmq_server_password** (String) RabbitMQ server password
+- `comment` (String) Comment about the target
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
+- `rabbitmq_server_password` (String) RabbitMQ server password
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_ssh.md
+++ b/docs/resources/target_ssh.md
@@ -17,18 +17,21 @@ SSH Target resource
 
 ### Required
 
-- **name** (String) Target name
+- `name` (String) Target name
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **host** (String) SSH host name
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
-- **port** (String) SSH port
-- **private_key** (String) SSH private key
-- **private_key_password** (String) SSH private key password
-- **ssh_password** (String) SSH password to rotate
-- **ssh_username** (String) SSH username
+- `comment` (String) Comment about the target
+- `host` (String) SSH host name
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
+- `port` (String) SSH port
+- `private_key` (String) SSH private key
+- `private_key_password` (String) SSH private key password
+- `ssh_password` (String) SSH password to rotate
+- `ssh_username` (String) SSH username
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/target_web.md
+++ b/docs/resources/target_web.md
@@ -17,13 +17,16 @@ Web Target resource
 
 ### Required
 
-- **name** (String) Target name
-- **url** (String) Web target URL
+- `name` (String) Target name
+- `url` (String) Web target URL
 
 ### Optional
 
-- **comment** (String) Comment about the target
-- **id** (String) The ID of this resource.
-- **key** (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
+- `comment` (String) Comment about the target
+- `key` (String) Key name. The key will be used to encrypt the target secret value. If key name is not specified, the account default protection key is used
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/examples/resources/akeyless_auth_method/resource.tf
+++ b/examples/resources/akeyless_auth_method/resource.tf
@@ -30,6 +30,7 @@ resource "akeyless_auth_method" "aws_iam" {
   }
 }
 
+
 data "akeyless_auth_method" "api_key" {
   path = "auth-method-api-key"
 }

--- a/examples/resources/akeyless_saml_auth_method/resource.tf
+++ b/examples/resources/akeyless_saml_auth_method/resource.tf
@@ -1,0 +1,5 @@
+resource "akeyless_auth_method_saml" "saml_auth" {
+  name                  = "auth-method-saml"
+  unique_identifier     = "email"
+  idp_metadata_xml_data = file("saml-metadata.xml")
+}

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
 # Use Semantic versioning only. Please update the version number before opening a pull request.
-v1.1.8
+v1.2.0


### PR DESCRIPTION
I added the ability to add idp_metadata_xml_data to the saml_auth method.  One possible use would be to use it as a file, but for other saml apps I've created their saml app in okta, which generated an xml output, which I've used as the input to this type of field, so it would help with automating building akeyless apps in okta and then using the xml metadata from that to build the saml_auth method in akeyless via terraform.
I made idp_metadata_xml_data optional, and changed idp_metadata_url from required to optional as well since you'd only use one.  I wasn't sure if I should bump up the minor or patch version here since it does technically add functionality, I did the minor version.
Thank you!