### PR TITLE
[Fixed] resource_role when updating to empty rules

### DIFF
--- a/akeyless/resource_role.go
+++ b/akeyless/resource_role.go
@@ -305,25 +305,24 @@ func resourceRoleUpdate(d *schema.ResourceData, m interface{}) (err error) {
 
 	rulesSet := d.Get("rules").(*schema.Set)
 	roleRulesNewValues := rulesSet.List()
-	if len(roleRulesNewValues) > 0 {
-		roleRulesOldValues := extractRoleRuleOldValues(rules.PathRules)
 
-		rulesToAdd := extractRulesToSet(roleRulesNewValues, roleRulesOldValues)
-		rulesToDelete := extractRulesToSet(roleRulesOldValues, roleRulesNewValues)
+	roleRulesOldValues := extractRoleRuleOldValues(rules.PathRules)
 
-		err, ok = setRoleRules(ctx, name, rulesToDelete, rulesToAdd, m)
-		if !ok {
-			return err
-		}
-		defer func() {
-			if !ok {
-				err, _ = setRoleRules(ctx, name, rulesToAdd, rulesToDelete, m)
-				if err != nil {
-					err = fmt.Errorf("fatal error, can't delete new role rules after bad update: %v", err)
-				}
-			}
-		}()
+	rulesToAdd := extractRulesToSet(roleRulesNewValues, roleRulesOldValues)
+	rulesToDelete := extractRulesToSet(roleRulesOldValues, roleRulesNewValues)
+
+	err, ok = setRoleRules(ctx, name, rulesToDelete, rulesToAdd, m)
+	if !ok {
+		return err
 	}
+	defer func() {
+		if !ok {
+			err, _ = setRoleRules(ctx, name, rulesToAdd, rulesToDelete, m)
+			if err != nil {
+				err = fmt.Errorf("fatal error, can't delete new role rules after bad update: %v", err)
+			}
+		}
+	}()
 
 	accessRulesNewValues := getNewAccessRules(d)
 	accessRulesOldValues := saveRoleAccessRuleOldValues(rules.PathRules)


### PR DESCRIPTION
## Changes: 
BugFix - `resource_role`updating to empty `rules`