### PR TITLE
Fix resource_auth_method_api_key description

### DIFF
--- a/akeyless/resource_auth_method_api_key.go
+++ b/akeyless/resource_auth_method_api_key.go
@@ -14,7 +14,7 @@ import (
 
 func resourceAuthMethodApiKey() *schema.Resource {
 	return &schema.Resource{
-		Description: "AWS API Key Auth Method Resource",
+		Description: "API Key Auth Method Resource",
 		Create:      resourceAuthMethodApiKeyCreate,
 		Read:        resourceAuthMethodApiKeyRead,
 		Update:      resourceAuthMethodApiKeyUpdate,


### PR DESCRIPTION
The akeyless_auth_method_api_key resource [documentation ](https://registry.terraform.io/providers/akeyless-community/akeyless/latest/docs/resources/auth_method_api_key) incorrectly identifies this resource as being specific to AWS.