### PR TITLE
Update Terraform gaps

### DIFF
--- a/akeyless/provider.go
+++ b/akeyless/provider.go
@@ -151,7 +151,7 @@ func Provider() *schema.Provider {
 					Schema: map[string]*schema.Schema{
 						"access_id": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 						"uid_token": {
 							Type:        schema.TypeString,

--- a/akeyless/resource_auth_method.go
+++ b/akeyless/resource_auth_method.go
@@ -59,12 +59,6 @@ func resourceAuthMethod() *schema.Resource {
 					Schema: map[string]*schema.Schema{},
 				},
 			},
-			"audit_logs_claims": {
-				Type:        schema.TypeSet,
-				Optional:    true,
-				Description: "Subclaims to include in audit logs",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
 			"saml": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -406,17 +400,14 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 		boundIpsList = common.ExpandStringList(boundIps.List())
 	}
 	accessExpires := int64(d.Get("access_expires").(int))
-	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
-	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	apiKeyAuthMethod := d.Get("api_key").([]interface{})
 	if len(apiKeyAuthMethod) == 1 {
 		body := akeyless_api.CreateAuthMethod{
-			Name:            path,
-			BoundIps:        &boundIpsList,
-			AccessExpires:   &accessExpires,
-			Token:           &token,
-			AuditLogsClaims: &subClaims,
+			Name:          path,
+			BoundIps:      &boundIpsList,
+			AccessExpires: &accessExpires,
+			Token:         &token,
 		}
 		apiKey, _, err := client.CreateAuthMethod(ctx).Body(body).Execute()
 		if err != nil {
@@ -450,7 +441,6 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 			IdpMetadataXmlData: akeyless_api.PtrString(idpMetadataXmlData),
 			UniqueIdentifier:   uniqueIdentifier,
 			Token:              &token,
-			AuditLogsClaims:    &subClaims,
 		}
 		apiKey, _, err := client.CreateAuthMethodSAML(ctx).Body(body).Execute()
 		if err != nil {
@@ -497,7 +487,6 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 			BoundUserName:     &boundUserNameList,
 			BoundResourceId:   &boundResourceIDList,
 			Token:             &token,
-			AuditLogsClaims:   &subClaims,
 		}
 		apiKey, _, err := client.CreateAuthMethodAWSIAM(ctx).Body(body).Execute()
 		if err != nil {
@@ -560,7 +549,6 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 			Audience:           akeyless_api.PtrString(audience),
 			Issuer:             akeyless_api.PtrString(issuer),
 			Token:              &token,
-			AuditLogsClaims:    &subClaims,
 		}
 		apiKey, _, err := client.CreateAuthMethodAzureAD(ctx).Body(body).Execute()
 		if err != nil {
@@ -586,7 +574,6 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 			Audience:                audience,
 			ServiceAccountCredsData: akeyless_api.PtrString(serviceAccountCredsData),
 			Token:                   &token,
-			AuditLogsClaims:         &subClaims,
 		}
 
 		iam := gcp["iam"].([]interface{})

--- a/akeyless/resource_auth_method.go
+++ b/akeyless/resource_auth_method.go
@@ -59,6 +59,12 @@ func resourceAuthMethod() *schema.Resource {
 					Schema: map[string]*schema.Schema{},
 				},
 			},
+			"audit_logs_claims": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Subclaims to include in audit logs",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"saml": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -400,14 +406,17 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 		boundIpsList = common.ExpandStringList(boundIps.List())
 	}
 	accessExpires := int64(d.Get("access_expires").(int))
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	apiKeyAuthMethod := d.Get("api_key").([]interface{})
 	if len(apiKeyAuthMethod) == 1 {
 		body := akeyless_api.CreateAuthMethod{
-			Name:          path,
-			BoundIps:      &boundIpsList,
-			AccessExpires: &accessExpires,
-			Token:         &token,
+			Name:            path,
+			BoundIps:        &boundIpsList,
+			AccessExpires:   &accessExpires,
+			Token:           &token,
+			AuditLogsClaims: &subClaims,
 		}
 		apiKey, _, err := client.CreateAuthMethod(ctx).Body(body).Execute()
 		if err != nil {
@@ -441,6 +450,7 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 			IdpMetadataXmlData: akeyless_api.PtrString(idpMetadataXmlData),
 			UniqueIdentifier:   uniqueIdentifier,
 			Token:              &token,
+			AuditLogsClaims:    &subClaims,
 		}
 		apiKey, _, err := client.CreateAuthMethodSAML(ctx).Body(body).Execute()
 		if err != nil {
@@ -487,6 +497,7 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 			BoundUserName:     &boundUserNameList,
 			BoundResourceId:   &boundResourceIDList,
 			Token:             &token,
+			AuditLogsClaims:   &subClaims,
 		}
 		apiKey, _, err := client.CreateAuthMethodAWSIAM(ctx).Body(body).Execute()
 		if err != nil {
@@ -549,6 +560,7 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 			Audience:           akeyless_api.PtrString(audience),
 			Issuer:             akeyless_api.PtrString(issuer),
 			Token:              &token,
+			AuditLogsClaims:    &subClaims,
 		}
 		apiKey, _, err := client.CreateAuthMethodAzureAD(ctx).Body(body).Execute()
 		if err != nil {
@@ -574,6 +586,7 @@ func createAuthMethod(d *schema.ResourceData, m interface{}) error {
 			Audience:                audience,
 			ServiceAccountCredsData: akeyless_api.PtrString(serviceAccountCredsData),
 			Token:                   &token,
+			AuditLogsClaims:         &subClaims,
 		}
 
 		iam := gcp["iam"].([]interface{})

--- a/akeyless/resource_auth_method_aws_iam.go
+++ b/akeyless/resource_auth_method_aws_iam.go
@@ -116,6 +116,12 @@ func resourceAuthMethodAwsIam() *schema.Resource {
 				Computed:    true,
 				Description: "Auth Method access ID",
 			},
+			"audit_logs_claims": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Subclaims to include in audit logs",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -148,6 +154,8 @@ func resourceAuthMethodAwsIamCreate(d *schema.ResourceData, m interface{}) error
 	boundUserName := common.ExpandStringList(boundUserNameSet.List())
 	boundUserIdSet := d.Get("bound_user_id").(*schema.Set)
 	boundUserId := common.ExpandStringList(boundUserIdSet.List())
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.CreateAuthMethodAWSIAM{
 		Name:              name,
@@ -165,6 +173,7 @@ func resourceAuthMethodAwsIamCreate(d *schema.ResourceData, m interface{}) error
 	common.GetAkeylessPtr(&body.BoundResourceId, boundResourceId)
 	common.GetAkeylessPtr(&body.BoundUserName, boundUserName)
 	common.GetAkeylessPtr(&body.BoundUserId, boundUserId)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	rOut, _, err := client.CreateAuthMethodAWSIAM(ctx).Body(body).Execute()
 	if err != nil {
@@ -302,6 +311,12 @@ func resourceAuthMethodAwsIamRead(d *schema.ResourceData, m interface{}) error {
 			return err
 		}
 	}
+	if rOut.AccessInfo.AuditLogsClaims != nil {
+		err = d.Set("audit_logs_claims", *rOut.AccessInfo.AuditLogsClaims)
+		if err != nil {
+			return err
+		}
+	}
 
 	d.SetId(path)
 
@@ -336,6 +351,8 @@ func resourceAuthMethodAwsIamUpdate(d *schema.ResourceData, m interface{}) error
 	boundUserName := common.ExpandStringList(boundUserNameSet.List())
 	boundUserIdSet := d.Get("bound_user_id").(*schema.Set)
 	boundUserId := common.ExpandStringList(boundUserIdSet.List())
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.UpdateAuthMethodAWSIAM{
 		Name:              name,
@@ -354,6 +371,7 @@ func resourceAuthMethodAwsIamUpdate(d *schema.ResourceData, m interface{}) error
 	common.GetAkeylessPtr(&body.BoundUserName, boundUserName)
 	common.GetAkeylessPtr(&body.BoundUserId, boundUserId)
 	common.GetAkeylessPtr(&body.NewName, name)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	_, _, err := client.UpdateAuthMethodAWSIAM(ctx).Body(body).Execute()
 	if err != nil {

--- a/akeyless/resource_auth_method_azure_ad.go
+++ b/akeyless/resource_auth_method_azure_ad.go
@@ -143,6 +143,12 @@ func resourceAuthMethodAzureAd() *schema.Resource {
 				Computed:    true,
 				Description: "Auth Method access ID",
 			},
+			"audit_logs_claims": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Subclaims to include in audit logs",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -180,6 +186,8 @@ func resourceAuthMethodAzureAdCreate(d *schema.ResourceData, m interface{}) erro
 	boundResourceNames := common.ExpandStringList(boundResourceNamesSet.List())
 	boundResourceIdSet := d.Get("bound_resource_id").(*schema.Set)
 	boundResourceId := common.ExpandStringList(boundResourceIdSet.List())
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.CreateAuthMethodAzureAD{
 		Name:          name,
@@ -201,6 +209,7 @@ func resourceAuthMethodAzureAdCreate(d *schema.ResourceData, m interface{}) erro
 	common.GetAkeylessPtr(&body.BoundResourceTypes, boundResourceTypes)
 	common.GetAkeylessPtr(&body.BoundResourceNames, boundResourceNames)
 	common.GetAkeylessPtr(&body.BoundResourceId, boundResourceId)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	rOut, _, err := client.CreateAuthMethodAzureAD(ctx).Body(body).Execute()
 	if err != nil {
@@ -364,6 +373,12 @@ func resourceAuthMethodAzureAdRead(d *schema.ResourceData, m interface{}) error 
 			return err
 		}
 	}
+	if rOut.AccessInfo.AuditLogsClaims != nil {
+		err = d.Set("audit_logs_claims", *rOut.AccessInfo.AuditLogsClaims)
+		if err != nil {
+			return err
+		}
+	}
 
 	d.SetId(path)
 
@@ -403,6 +418,8 @@ func resourceAuthMethodAzureAdUpdate(d *schema.ResourceData, m interface{}) erro
 	boundResourceNames := common.ExpandStringList(boundResourceNamesSet.List())
 	boundResourceIdSet := d.Get("bound_resource_id").(*schema.Set)
 	boundResourceId := common.ExpandStringList(boundResourceIdSet.List())
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.UpdateAuthMethodAzureAD{
 		Name:          name,
@@ -424,6 +441,7 @@ func resourceAuthMethodAzureAdUpdate(d *schema.ResourceData, m interface{}) erro
 	common.GetAkeylessPtr(&body.BoundResourceTypes, boundResourceTypes)
 	common.GetAkeylessPtr(&body.BoundResourceNames, boundResourceNames)
 	common.GetAkeylessPtr(&body.BoundResourceId, boundResourceId)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 	common.GetAkeylessPtr(&body.NewName, name)
 
 	_, _, err := client.UpdateAuthMethodAzureAD(ctx).Body(body).Execute()

--- a/akeyless/resource_auth_method_gcp.go
+++ b/akeyless/resource_auth_method_gcp.go
@@ -114,6 +114,12 @@ func resourceAuthMethodGcp() *schema.Resource {
 				Computed:    true,
 				Description: "Auth Method access ID",
 			},
+			"audit_logs_claims": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Subclaims to include in audit logs",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -144,6 +150,8 @@ func resourceAuthMethodGcpCreate(d *schema.ResourceData, m interface{}) error {
 	boundRegions := common.ExpandStringList(boundRegionsSet.List())
 	boundLabelsSet := d.Get("bound_labels").(*schema.Set)
 	boundLabels := common.ExpandStringList(boundLabelsSet.List())
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.CreateAuthMethodGCP{
 		Name:     name,
@@ -161,6 +169,7 @@ func resourceAuthMethodGcpCreate(d *schema.ResourceData, m interface{}) error {
 	common.GetAkeylessPtr(&body.BoundZones, boundZones)
 	common.GetAkeylessPtr(&body.BoundRegions, boundRegions)
 	common.GetAkeylessPtr(&body.BoundLabels, boundLabels)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	rOut, _, err := client.CreateAuthMethodGCP(ctx).Body(body).Execute()
 	if err != nil {
@@ -309,6 +318,13 @@ func resourceAuthMethodGcpRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
+	if rOut.AccessInfo.AuditLogsClaims != nil {
+		err = d.Set("audit_logs_claims", *rOut.AccessInfo.AuditLogsClaims)
+		if err != nil {
+			return err
+		}
+	}
+
 	d.SetId(path)
 
 	return nil
@@ -340,6 +356,8 @@ func resourceAuthMethodGcpUpdate(d *schema.ResourceData, m interface{}) error {
 	boundRegions := common.ExpandStringList(boundRegionsSet.List())
 	boundLabelsSet := d.Get("bound_labels").(*schema.Set)
 	boundLabels := common.ExpandStringList(boundLabelsSet.List())
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.UpdateAuthMethodGCP{
 		Name:     name,
@@ -358,6 +376,7 @@ func resourceAuthMethodGcpUpdate(d *schema.ResourceData, m interface{}) error {
 	common.GetAkeylessPtr(&body.BoundRegions, boundRegions)
 	common.GetAkeylessPtr(&body.BoundLabels, boundLabels)
 	common.GetAkeylessPtr(&body.NewName, name)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	_, _, err := client.UpdateAuthMethodGCP(ctx).Body(body).Execute()
 	if err != nil {

--- a/akeyless/resource_auth_method_oauth2.go
+++ b/akeyless/resource_auth_method_oauth2.go
@@ -97,6 +97,12 @@ func resourceAuthMethodOauth2() *schema.Resource {
 				Computed:    true,
 				Description: "Auth Method access ID",
 			},
+			"audit_logs_claims": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Subclaims to include in audit logs",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -121,6 +127,8 @@ func resourceAuthMethodOauth2Create(d *schema.ResourceData, m interface{}) error
 	boundClientIds := common.ExpandStringList(boundClientIdsSet.List())
 	issuer := d.Get("issuer").(string)
 	audience := d.Get("audience").(string)
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.CreateAuthMethodOAuth2{
 		Name:             name,
@@ -136,6 +144,7 @@ func resourceAuthMethodOauth2Create(d *schema.ResourceData, m interface{}) error
 	common.GetAkeylessPtr(&body.Issuer, issuer)
 	common.GetAkeylessPtr(&body.Audience, audience)
 	common.GetAkeylessPtr(&body.JwksJsonData, jwksJsonData)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	rOut, _, err := client.CreateAuthMethodOAuth2(ctx).Body(body).Execute()
 	if err != nil {
@@ -267,6 +276,13 @@ func resourceAuthMethodOauth2Read(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
+	if rOut.AccessInfo.AuditLogsClaims != nil {
+		err = d.Set("audit_logs_claims", *rOut.AccessInfo.AuditLogsClaims)
+		if err != nil {
+			return err
+		}
+	}
+
 	d.SetId(path)
 
 	return nil
@@ -292,6 +308,8 @@ func resourceAuthMethodOauth2Update(d *schema.ResourceData, m interface{}) error
 	boundClientIds := common.ExpandStringList(boundClientIdsSet.List())
 	issuer := d.Get("issuer").(string)
 	audience := d.Get("audience").(string)
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.UpdateAuthMethodOAuth2{
 		Name:             name,
@@ -308,6 +326,7 @@ func resourceAuthMethodOauth2Update(d *schema.ResourceData, m interface{}) error
 	common.GetAkeylessPtr(&body.Audience, audience)
 	common.GetAkeylessPtr(&body.NewName, name)
 	common.GetAkeylessPtr(&body.JwksJsonData, jwksJsonData)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	_, _, err := client.UpdateAuthMethodOAuth2(ctx).Body(body).Execute()
 	if err != nil {

--- a/akeyless/resource_auth_method_oidc.go
+++ b/akeyless/resource_auth_method_oidc.go
@@ -102,6 +102,12 @@ func resourceAuthMethodOidc() *schema.Resource {
 				Computed:    true,
 				Description: "Auth Method access ID",
 			},
+			"audit_logs_claims": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Subclaims to include in audit logs",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -128,6 +134,8 @@ func resourceAuthMethodOidcCreate(d *schema.ResourceData, m interface{}) error {
 	requiredScopesSet := d.Get("required_scopes").(*schema.Set)
 	requiredScopes := common.ExpandStringList(requiredScopesSet.List())
 	requiredScopesPrefix := d.Get("required_scopes_prefix").(string)
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.CreateAuthMethodOIDC{
 		Name:             name,
@@ -144,6 +152,7 @@ func resourceAuthMethodOidcCreate(d *schema.ResourceData, m interface{}) error {
 	common.GetAkeylessPtr(&body.AllowedRedirectUri, allowedRedirectUri)
 	common.GetAkeylessPtr(&body.RequiredScopes, requiredScopes)
 	common.GetAkeylessPtr(&body.RequiredScopesPrefix, requiredScopesPrefix)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	rOut, _, err := client.CreateAuthMethodOIDC(ctx).Body(body).Execute()
 	if err != nil {
@@ -280,6 +289,13 @@ func resourceAuthMethodOidcRead(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
+	if rOut.AccessInfo.AuditLogsClaims != nil {
+		err = d.Set("audit_logs_claims", *rOut.AccessInfo.AuditLogsClaims)
+		if err != nil {
+			return err
+		}
+	}
+
 	d.SetId(path)
 
 	return nil
@@ -307,6 +323,8 @@ func resourceAuthMethodOidcUpdate(d *schema.ResourceData, m interface{}) error {
 	requiredScopesSet := d.Get("required_scopes").(*schema.Set)
 	requiredScopes := common.ExpandStringList(requiredScopesSet.List())
 	requiredScopesPrefix := d.Get("required_scopes_prefix").(string)
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.UpdateAuthMethodOIDC{
 		Name:             name,
@@ -323,6 +341,7 @@ func resourceAuthMethodOidcUpdate(d *schema.ResourceData, m interface{}) error {
 	common.GetAkeylessPtr(&body.AllowedRedirectUri, allowedRedirectUri)
 	common.GetAkeylessPtr(&body.RequiredScopes, requiredScopes)
 	common.GetAkeylessPtr(&body.RequiredScopesPrefix, requiredScopesPrefix)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 	common.GetAkeylessPtr(&body.NewName, name)
 
 	_, _, err := client.UpdateAuthMethodOIDC(ctx).Body(body).Execute()

--- a/akeyless/resource_auth_method_saml.go
+++ b/akeyless/resource_auth_method_saml.go
@@ -85,6 +85,12 @@ func resourceAuthMethodSaml() *schema.Resource {
 				Computed:    true,
 				Description: "Auth Method access ID",
 			},
+			"audit_logs_claims": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Subclaims to include in audit logs",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -107,6 +113,8 @@ func resourceAuthMethodSamlCreate(d *schema.ResourceData, m interface{}) error {
 	idpMetadataXmlData := d.Get("idp_metadata_xml_data").(string)
 	allowedRedirectUriSet := d.Get("allowed_redirect_uri").(*schema.Set)
 	allowedRedirectUri := common.ExpandStringList(allowedRedirectUriSet.List())
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.CreateAuthMethodSAML{
 		Name:             name,
@@ -120,6 +128,7 @@ func resourceAuthMethodSamlCreate(d *schema.ResourceData, m interface{}) error {
 	common.GetAkeylessPtr(&body.IdpMetadataUrl, idpMetadataUrl)
 	common.GetAkeylessPtr(&body.IdpMetadataXmlData, idpMetadataXmlData)
 	common.GetAkeylessPtr(&body.AllowedRedirectUri, allowedRedirectUri)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	rOut, _, err := client.CreateAuthMethodSAML(ctx).Body(body).Execute()
 	if err != nil {
@@ -236,6 +245,12 @@ func resourceAuthMethodSamlRead(d *schema.ResourceData, m interface{}) error {
 			return err
 		}
 	}
+	if rOut.AccessInfo.AuditLogsClaims != nil {
+		err = d.Set("audit_logs_claims", *rOut.AccessInfo.AuditLogsClaims)
+		if err != nil {
+			return err
+		}
+	}
 
 	d.SetId(path)
 
@@ -260,6 +275,8 @@ func resourceAuthMethodSamlUpdate(d *schema.ResourceData, m interface{}) error {
 	idpMetadataXmlData := d.Get("idp_metadata_xml_data").(string)
 	allowedRedirectUriSet := d.Get("allowed_redirect_uri").(*schema.Set)
 	allowedRedirectUri := common.ExpandStringList(allowedRedirectUriSet.List())
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.UpdateAuthMethodSAML{
 		Name:             name,
@@ -273,6 +290,7 @@ func resourceAuthMethodSamlUpdate(d *schema.ResourceData, m interface{}) error {
 	common.GetAkeylessPtr(&body.IdpMetadataUrl, idpMetadataUrl)
 	common.GetAkeylessPtr(&body.IdpMetadataXmlData, idpMetadataXmlData)
 	common.GetAkeylessPtr(&body.AllowedRedirectUri, allowedRedirectUri)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 	common.GetAkeylessPtr(&body.NewName, name)
 
 	_, _, err := client.UpdateAuthMethodSAML(ctx).Body(body).Execute()

--- a/akeyless/resource_auth_method_test.go
+++ b/akeyless/resource_auth_method_test.go
@@ -17,6 +17,7 @@ func TestAuthMethodApiKeyResourceCreate(t *testing.T) {
 	config := fmt.Sprintf(`
 		resource "akeyless_auth_method" "%v" {
 			path = "%v"
+            audit_logs_claims = ["eee","kk"]
 			api_key {
 			}
 		}

--- a/akeyless/resource_auth_method_test.go
+++ b/akeyless/resource_auth_method_test.go
@@ -17,7 +17,6 @@ func TestAuthMethodApiKeyResourceCreate(t *testing.T) {
 	config := fmt.Sprintf(`
 		resource "akeyless_auth_method" "%v" {
 			path = "%v"
-            audit_logs_claims = ["eee","kk"]
 			api_key {
 			}
 		}

--- a/akeyless/resource_auth_method_universal_identity.go
+++ b/akeyless/resource_auth_method_universal_identity.go
@@ -80,6 +80,12 @@ func resourceAuthMethodUniversalIdentity() *schema.Resource {
 				Computed:    true,
 				Description: "Auth Method access ID",
 			},
+			"audit_logs_claims": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Subclaims to include in audit logs",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -100,6 +106,8 @@ func resourceAuthMethodUniversalIdentityCreate(d *schema.ResourceData, m interfa
 	denyRotate := d.Get("deny_rotate").(bool)
 	denyInheritance := d.Get("deny_inheritance").(bool)
 	ttl := d.Get("ttl").(int)
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.CreateAuthMethodUniversalIdentity{
 		Name:  name,
@@ -112,6 +120,7 @@ func resourceAuthMethodUniversalIdentityCreate(d *schema.ResourceData, m interfa
 	common.GetAkeylessPtr(&body.DenyRotate, denyRotate)
 	common.GetAkeylessPtr(&body.DenyInheritance, denyInheritance)
 	common.GetAkeylessPtr(&body.Ttl, ttl)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 
 	rOut, _, err := client.CreateAuthMethodUniversalIdentity(ctx).Body(body).Execute()
 	if err != nil {
@@ -218,6 +227,12 @@ func resourceAuthMethodUniversalIdentityRead(d *schema.ResourceData, m interface
 			return err
 		}
 	}
+	if rOut.AccessInfo.AuditLogsClaims != nil {
+		err = d.Set("audit_logs_claims", *rOut.AccessInfo.AuditLogsClaims)
+		if err != nil {
+			return err
+		}
+	}
 
 	d.SetId(path)
 
@@ -240,6 +255,8 @@ func resourceAuthMethodUniversalIdentityUpdate(d *schema.ResourceData, m interfa
 	denyRotate := d.Get("deny_rotate").(bool)
 	denyInheritance := d.Get("deny_inheritance").(bool)
 	ttl := d.Get("ttl").(int)
+	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
+	subClaims := common.ExpandStringList(subClaimsSet.List())
 
 	body := akeyless_api.UpdateAuthMethodUniversalIdentity{
 		Name:  name,
@@ -252,6 +269,7 @@ func resourceAuthMethodUniversalIdentityUpdate(d *schema.ResourceData, m interfa
 	common.GetAkeylessPtr(&body.DenyRotate, denyRotate)
 	common.GetAkeylessPtr(&body.DenyInheritance, denyInheritance)
 	common.GetAkeylessPtr(&body.Ttl, ttl)
+	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 	common.GetAkeylessPtr(&body.NewName, name)
 
 	_, _, err := client.UpdateAuthMethodUniversalIdentity(ctx).Body(body).Execute()

--- a/akeyless/resource_auth_methods_test.go
+++ b/akeyless/resource_auth_methods_test.go
@@ -39,7 +39,7 @@ func TestAuthMethodApiKeyResourceCreateNew(t *testing.T) {
 			name = "%v"
 			access_expires = 10001
 			bound_ips = ["1.1.4.0/32"]
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -78,7 +78,7 @@ func TestAuthMethodAWSResourceCreateNew(t *testing.T) {
 			name = "%v"
 			bound_aws_account_id = ["516111111111"]
 			bound_ips = ["1.1.1.0/32"]
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -119,7 +119,7 @@ func TestAuthMethodAzureResourceCreateNew(t *testing.T) {
 			bound_tenant_id = "my-tenant-id"
 			bound_ips = ["1.1.1.0/32"]
 			issuer = "https://sts.windows.net/sdfjskfjsdkcsjnc"
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -165,7 +165,7 @@ func TestAuthMethodCertResource(t *testing.T) {
 			certificate_data 	= "%v"
 			unique_identifier 	= "uid"
 			bound_ips 			= ["1.1.1.0/32"]
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path, cert)
 
@@ -197,7 +197,6 @@ func TestAuthMethodGCPResourceCreateNew(t *testing.T) {
 			bound_service_accounts = ["%v"]
 			type = "gce"
 			bound_ips = ["1.1.1.0/32"]
-            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path, os.Getenv("TF_ACC_GCP_SERVICE_ACCOUNT"), os.Getenv("TF_ACC_GCP_BOUND_SERVICE_ACC"))
 
@@ -239,7 +238,7 @@ func TestAuthMethodK8sResourceCreateNew(t *testing.T) {
 			access_expires = 1638741817
 			bound_ips = ["1.1.4.0/32"]
 			bound_pod_names = ["mypod1", "mypod3"]
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -282,7 +281,7 @@ func TestAuthMethodOauth2ResourceCreateNew(t *testing.T) {
 			jwks_uri = "https://test.wixpress.com"
 			bound_ips = ["1.1.1.0/32"]
 			access_expires = 1638741817
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -319,7 +318,6 @@ func TestAuthMethodOidcResourceCreateNew(t *testing.T) {
 			access_expires = 1638741817
 			required_scopes = ["email", "profile"]
 			required_scopes_prefix = "devops"
-            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 	configUpdate := fmt.Sprintf(`
@@ -332,7 +330,7 @@ func TestAuthMethodOidcResourceCreateNew(t *testing.T) {
 			bound_ips = ["1.1.1.0/32"]
 			required_scopes = ["id"]
 			required_scopes_prefix = "rnd"
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -376,7 +374,7 @@ func TestAuthMethodSAMLResourceCreateNew(t *testing.T) {
 			idp_metadata_url = "https://dev-1111.okta.com/app/abc12345/sso/saml/metadata"
 			unique_identifier = "email"
 			bound_ips = ["1.1.1.0/32"]
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -419,7 +417,7 @@ func TestAuthMethodSAMLWithXmlResourceCreateNew(t *testing.T) {
 			idp_metadata_xml_data = "<ss>ddddd<ss>"
 			unique_identifier = "email"
 			bound_ips = ["1.1.1.0/32"]
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -459,7 +457,7 @@ func TestAuthMethodUIDResourceCreateNew(t *testing.T) {
 			name = "%v"
 			deny_inheritance = false
 			bound_ips = ["1.1.1.0/32"]
-            audit_logs_claims = ["eitan","kk"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 

--- a/akeyless/resource_auth_methods_test.go
+++ b/akeyless/resource_auth_methods_test.go
@@ -31,6 +31,7 @@ func TestAuthMethodApiKeyResourceCreateNew(t *testing.T) {
 			bound_ips = ["1.1.1.0/32"]
 			force_sub_claims = true
 			jwt_ttl = 42
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 	configUpdate := fmt.Sprintf(`
@@ -38,6 +39,7 @@ func TestAuthMethodApiKeyResourceCreateNew(t *testing.T) {
 			name = "%v"
 			access_expires = 10001
 			bound_ips = ["1.1.4.0/32"]
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path)
 
@@ -68,6 +70,7 @@ func TestAuthMethodAWSResourceCreateNew(t *testing.T) {
 			name = "%v"
 			jwt_ttl = 42
 			bound_aws_account_id = ["516111111111"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 	configUpdate := fmt.Sprintf(`
@@ -75,6 +78,7 @@ func TestAuthMethodAWSResourceCreateNew(t *testing.T) {
 			name = "%v"
 			bound_aws_account_id = ["516111111111"]
 			bound_ips = ["1.1.1.0/32"]
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path)
 
@@ -105,6 +109,7 @@ func TestAuthMethodAzureResourceCreateNew(t *testing.T) {
 			name = "%v"
 			jwt_ttl = 42
 			bound_tenant_id = "my-tenant-id"
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -114,6 +119,7 @@ func TestAuthMethodAzureResourceCreateNew(t *testing.T) {
 			bound_tenant_id = "my-tenant-id"
 			bound_ips = ["1.1.1.0/32"]
 			issuer = "https://sts.windows.net/sdfjskfjsdkcsjnc"
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path)
 
@@ -149,6 +155,7 @@ func TestAuthMethodCertResource(t *testing.T) {
 			jwt_ttl 			= 42
 			certificate_data 	= "%v"
 			unique_identifier 	= "email"
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path, cert)
 
@@ -158,6 +165,7 @@ func TestAuthMethodCertResource(t *testing.T) {
 			certificate_data 	= "%v"
 			unique_identifier 	= "uid"
 			bound_ips 			= ["1.1.1.0/32"]
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path, cert)
 
@@ -178,6 +186,7 @@ func TestAuthMethodGCPResourceCreateNew(t *testing.T) {
 			service_account_creds_data = "%v"
 			bound_service_accounts = ["%v"]
 			type = "gce"
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path, os.Getenv("TF_ACC_GCP_SERVICE_ACCOUNT"), os.Getenv("TF_ACC_GCP_BOUND_SERVICE_ACC"))
 
@@ -188,6 +197,7 @@ func TestAuthMethodGCPResourceCreateNew(t *testing.T) {
 			bound_service_accounts = ["%v"]
 			type = "gce"
 			bound_ips = ["1.1.1.0/32"]
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path, os.Getenv("TF_ACC_GCP_SERVICE_ACCOUNT"), os.Getenv("TF_ACC_GCP_BOUND_SERVICE_ACC"))
 
@@ -220,6 +230,7 @@ func TestAuthMethodK8sResourceCreateNew(t *testing.T) {
 			jwt_ttl = 42
 			bound_ips = ["1.1.4.0/32"]
 			bound_pod_names = ["mypod1", "mypod2"]
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 	configUpdate := fmt.Sprintf(`
@@ -228,6 +239,7 @@ func TestAuthMethodK8sResourceCreateNew(t *testing.T) {
 			access_expires = 1638741817
 			bound_ips = ["1.1.4.0/32"]
 			bound_pod_names = ["mypod1", "mypod3"]
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path)
 
@@ -260,6 +272,7 @@ func TestAuthMethodOauth2ResourceCreateNew(t *testing.T) {
 			unique_identifier = "email"
 			jwks_uri = "https://test.wixpress.com"
 			access_expires = 1638741817
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 	configUpdate := fmt.Sprintf(`
@@ -269,6 +282,7 @@ func TestAuthMethodOauth2ResourceCreateNew(t *testing.T) {
 			jwks_uri = "https://test.wixpress.com"
 			bound_ips = ["1.1.1.0/32"]
 			access_expires = 1638741817
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path)
 
@@ -305,6 +319,7 @@ func TestAuthMethodOidcResourceCreateNew(t *testing.T) {
 			access_expires = 1638741817
 			required_scopes = ["email", "profile"]
 			required_scopes_prefix = "devops"
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 	configUpdate := fmt.Sprintf(`
@@ -317,6 +332,7 @@ func TestAuthMethodOidcResourceCreateNew(t *testing.T) {
 			bound_ips = ["1.1.1.0/32"]
 			required_scopes = ["id"]
 			required_scopes_prefix = "rnd"
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path)
 
@@ -350,6 +366,7 @@ func TestAuthMethodSAMLResourceCreateNew(t *testing.T) {
 			jwt_ttl = 42
 			idp_metadata_url = "https://dev-1111.okta.com/app/abc12345/sso/saml/metadata"
 			unique_identifier = "email"
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -359,6 +376,7 @@ func TestAuthMethodSAMLResourceCreateNew(t *testing.T) {
 			idp_metadata_url = "https://dev-1111.okta.com/app/abc12345/sso/saml/metadata"
 			unique_identifier = "email"
 			bound_ips = ["1.1.1.0/32"]
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path)
 
@@ -391,6 +409,7 @@ func TestAuthMethodSAMLWithXmlResourceCreateNew(t *testing.T) {
 			name = "%v"
 			idp_metadata_xml_data = "<ss>cccc<ss>"
 			unique_identifier = "email"
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 
@@ -400,6 +419,7 @@ func TestAuthMethodSAMLWithXmlResourceCreateNew(t *testing.T) {
 			idp_metadata_xml_data = "<ss>ddddd<ss>"
 			unique_identifier = "email"
 			bound_ips = ["1.1.1.0/32"]
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path)
 
@@ -431,6 +451,7 @@ func TestAuthMethodUIDResourceCreateNew(t *testing.T) {
 			jwt_ttl = 42
 			deny_inheritance = true
 			ttl = 120
+            audit_logs_claims = ["eee","kk"]
 		}
 	`, name, path)
 	configUpdate := fmt.Sprintf(`
@@ -438,6 +459,7 @@ func TestAuthMethodUIDResourceCreateNew(t *testing.T) {
 			name = "%v"
 			deny_inheritance = false
 			bound_ips = ["1.1.1.0/32"]
+            audit_logs_claims = ["eitan","kk"]
 		}
 	`, name, path)
 

--- a/akeyless/resource_dynamic_secret_github.go
+++ b/akeyless/resource_dynamic_secret_github.go
@@ -36,12 +36,12 @@ func resourceDynamicSecretGithub() *schema.Resource {
 			"installation_organization": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Optional, instead of installation id, set a GitHub organization name",
+				Description: "Instead of installation id, set a GitHub organization name",
 			},
 			"installation_repository": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Optional, instead of installation id, set a GitHub repository '<owner>/<repo-name>'",
+				Description: "Instead of installation id, set a GitHub repository '<owner>/<repo-name>'",
 			},
 			"target_name": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_dynamic_secret_github.go
+++ b/akeyless/resource_dynamic_secret_github.go
@@ -173,6 +173,7 @@ func resourceDynamicSecretGithubRead(d *schema.ResourceData, m interface{}) erro
 		}
 	}
 
+	// Akeyless might return more than one installation, but we will update only if we work appropriately with one installation.
 	// installation_id is relevant when installation_organization and installation_repository aren't (need exactly one)
 	if rOut.GithubInstallationId != nil {
 		if d.Get("installation_repository").(string) == "" && d.Get("installation_organization").(string) == "" {

--- a/akeyless/resource_dynamic_secret_test.go
+++ b/akeyless/resource_dynamic_secret_test.go
@@ -1,0 +1,45 @@
+package akeyless
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGithubDynamicSecretResource(t *testing.T) {
+
+	t.Skip("for now the requested values are fictive")
+
+	name := "github_test"
+	itemPath := testPath(name)
+	config := fmt.Sprintf(`
+		resource "akeyless_dynamic_secret_github" "%v" {
+			name            		= "%v"
+			installation_id 		= "%v"
+			token_permissions 	   	= %v
+			github_app_id 		  	= %v
+			github_app_private_key	= "%v"
+		}
+	`, name, itemPath, GITHUB_INSTALL_ID, GITHUB_TOKEN_PERM, GITHUB_APP_ID, GITHUB_APP_KEY)
+
+	configUpdate := fmt.Sprintf(`
+		resource "akeyless_dynamic_secret_github" "%v" {
+			name            		= "%v"
+			installation_repository = "%v"
+			token_repositories 		= %v
+			github_app_id 			= %v
+			github_app_private_key 	= "%v"
+		}
+	`, name, itemPath, GITHUB_INSTALL_REPO, GITHUB_TOKEN_REPO, GITHUB_APP_ID, GITHUB_APP_KEY)
+
+	configUpdate2 := fmt.Sprintf(`
+		resource "akeyless_dynamic_secret_github" "%v" {
+			name            			= "%v"
+			installation_organization 	= "%v"
+			token_repositories 			= %v
+			github_app_id 				= %v
+			github_app_private_key 		= "%v"
+		}
+	`, name, itemPath, GITHUB_INSTALL_ORGANIZATION, GITHUB_TOKEN_REPO, GITHUB_APP_ID, GITHUB_APP_KEY)
+
+	testItemResource(t, itemPath, config, configUpdate, configUpdate2)
+}

--- a/akeyless/resource_dynamic_secret_test.go
+++ b/akeyless/resource_dynamic_secret_test.go
@@ -41,5 +41,60 @@ func TestGithubDynamicSecretResource(t *testing.T) {
 		}
 	`, name, itemPath, GITHUB_INSTALL_ORGANIZATION, GITHUB_TOKEN_REPO, GITHUB_APP_ID, GITHUB_APP_KEY)
 
-	testItemResource(t, itemPath, config, configUpdate, configUpdate2)
+	configUpdate3 := fmt.Sprintf(`
+		resource "akeyless_dynamic_secret_github" "%v" {
+			name            			= "%v"
+			installation_id 			= "%v"
+			installation_organization 	= "%v"
+			token_repositories 			= %v
+			github_app_id 				= %v
+			github_app_private_key 		= "%v"
+		}
+	`, name, itemPath, GITHUB_INSTALL_ID, GITHUB_INSTALL_ORGANIZATION, GITHUB_TOKEN_REPO, GITHUB_APP_ID, GITHUB_APP_KEY)
+
+	configUpdate4 := fmt.Sprintf(`
+		resource "akeyless_dynamic_secret_github" "%v" {
+			name            			= "%v"
+			installation_id 			= "%v"
+			installation_repository 	= "%v"
+			installation_organization 	= "%v"
+			token_repositories 			= %v
+			github_app_id 				= %v
+			github_app_private_key 		= "%v"
+		}
+	`, name, itemPath, GITHUB_INSTALL_ID, GITHUB_INSTALL_REPO, GITHUB_INSTALL_ORGANIZATION, GITHUB_TOKEN_REPO, GITHUB_APP_ID, GITHUB_APP_KEY)
+
+	configUpdate5 := fmt.Sprintf(`
+		resource "akeyless_dynamic_secret_github" "%v" {
+			name            			= "%v"
+			installation_repository 	= "%v"
+			token_repositories 			= %v
+			github_app_id 				= %v
+			github_app_private_key 		= "%v"
+		}
+	`, name, itemPath, GITHUB_INSTALL_REPO, GITHUB_TOKEN_REPO, GITHUB_APP_ID, GITHUB_APP_KEY)
+
+	configUpdate6 := fmt.Sprintf(`
+		resource "akeyless_dynamic_secret_github" "%v" {
+			name            			= "%v"
+			installation_id 			= "%v"
+			installation_repository 	= "%v"
+			installation_organization 	= "%v"
+			token_repositories 			= %v
+			github_app_id 				= %v
+			github_app_private_key 		= "%v"
+		}
+	`, name, itemPath, GITHUB_INSTALL_ID, GITHUB_INSTALL_REPO, GITHUB_INSTALL_ORGANIZATION, GITHUB_TOKEN_REPO, GITHUB_APP_ID, GITHUB_APP_KEY)
+
+	configUpdate7 := fmt.Sprintf(`
+		resource "akeyless_dynamic_secret_github" "%v" {
+			name            			= "%v"
+			installation_id 			= "%v"
+			token_repositories 			= %v
+			github_app_id 				= %v
+			github_app_private_key 		= "%v"
+		}
+	`, name, itemPath, GITHUB_INSTALL_ID, GITHUB_TOKEN_REPO, GITHUB_APP_ID, GITHUB_APP_KEY)
+
+	testItemResource(t, itemPath, config, configUpdate, configUpdate2, configUpdate3, configUpdate4, configUpdate5, configUpdate6, configUpdate7)
 }

--- a/akeyless/resource_item_test.go
+++ b/akeyless/resource_item_test.go
@@ -57,7 +57,7 @@ func TestDfcKeyRsaResource(t *testing.T) {
 		}
 	`, name, itemPath, cert)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestDfcKeyAesResource(t *testing.T) {
@@ -81,7 +81,7 @@ func TestDfcKeyAesResource(t *testing.T) {
 		}
 	`, name, itemPath)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestRsaPublicResource(t *testing.T) {
@@ -102,7 +102,7 @@ func TestRsaPublicResource(t *testing.T) {
 
 	configUpdate := config
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestClassicKey(t *testing.T) {
@@ -130,7 +130,7 @@ func TestClassicKey(t *testing.T) {
 		}
 	`, name, itemPath)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestPkiResource(t *testing.T) {
@@ -202,7 +202,7 @@ func TestPkiResource(t *testing.T) {
 		}
 	`, name, itemPath, keyPath)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestPkiDataSource(t *testing.T) {
@@ -321,7 +321,7 @@ func TestSshCertResource(t *testing.T) {
 		}
 	`, name, itemPath)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestSshDataSource(t *testing.T) {
@@ -436,24 +436,20 @@ func TestCertificateDataSource(t *testing.T) {
 	tesItemDataSource(t, config, "certificate", []string{"certificate_pem", "private_key_pem"})
 }
 
-func tesItemResource(t *testing.T, config, configUpdate, itemPath string) {
+func testItemResource(t *testing.T, itemPath string, configs ...string) {
+	steps := make([]resource.TestStep, len(configs))
+	for i, config := range configs {
+		steps[i] = resource.TestStep{
+			Config: config,
+			Check: resource.ComposeTestCheckFunc(
+				checkItemExistsRemotely(itemPath),
+			),
+		}
+	}
+
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				//PreConfig: deleteFunc,
-				Check: resource.ComposeTestCheckFunc(
-					checkItemExistsRemotely(itemPath),
-				),
-			},
-			{
-				Config: configUpdate,
-				Check: resource.ComposeTestCheckFunc(
-					checkItemExistsRemotely(itemPath),
-				),
-			},
-		},
+		Steps:             steps,
 	})
 }
 

--- a/akeyless/resource_producer_test.go
+++ b/akeyless/resource_producer_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	GITHUB_INSTALL_ID           = 1234
 	GITHUB_INSTALL_ORGANIZATION = "XXXXXXXX"
 	GITHUB_INSTALL_REPO         = "XXXXXXXX"
 	GITHUB_APP_ID               = 1234
@@ -86,7 +87,7 @@ func TestK8sProducerResource(t *testing.T) {
 		}
 	`, name, itemPath, K8S_HOST, K8S_CERT, K8S_TOKEN)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestGithubProducerResource(t *testing.T) {
@@ -97,13 +98,13 @@ func TestGithubProducerResource(t *testing.T) {
 	itemPath := testPath(name)
 	config := fmt.Sprintf(`
 		resource "akeyless_producer_github" "%v" {
-			name            		  = "%v"
-			installation_organization = "%v"
-			token_permissions 		  = %v
-			github_app_id 			  = %v
-			github_app_private_key 	  = "%v"
+			name            		= "%v"
+			installation_id 		= "%v"
+			token_permissions 	   	= %v
+			github_app_id 		  	= %v
+			github_app_private_key	= "%v"
 		}
-	`, name, itemPath, GITHUB_INSTALL_ORGANIZATION, GITHUB_TOKEN_PERM, GITHUB_APP_ID, GITHUB_APP_KEY)
+	`, name, itemPath, GITHUB_INSTALL_ID, GITHUB_TOKEN_PERM, GITHUB_APP_ID, GITHUB_APP_KEY)
 
 	configUpdate := fmt.Sprintf(`
 		resource "akeyless_producer_github" "%v" {
@@ -115,7 +116,7 @@ func TestGithubProducerResource(t *testing.T) {
 		}
 	`, name, itemPath, GITHUB_INSTALL_REPO, GITHUB_TOKEN_REPO, GITHUB_APP_ID, GITHUB_APP_KEY)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestGitlabProducerResource(t *testing.T) {
@@ -158,7 +159,7 @@ func TestGitlabProducerResource(t *testing.T) {
 		}
 	`, name, itemPath, GITLAB_TOKEN)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestCustomProducerResource(t *testing.T) {
@@ -188,7 +189,7 @@ func TestCustomProducerResource(t *testing.T) {
 		}
 	`, name, itemPath)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestMySqlProducerResource(t *testing.T) {
@@ -215,7 +216,7 @@ func TestMySqlProducerResource(t *testing.T) {
 		}
 	`, name, itemPath, mysql_attr)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestGcpProducerResource(t *testing.T) {
@@ -247,7 +248,7 @@ func TestGcpProducerResource(t *testing.T) {
 		}
 	`, name, itemPath, GCP_SA_EMAIL, GCP_TOKEN_SCOPES, GCP_KEY)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestRotatedSecretResource(t *testing.T) {
@@ -309,7 +310,7 @@ func TestRotatedSecretResource(t *testing.T) {
 		}
 	`, targetName, targetPath, db_attr, user, password, rsName, rsPath, targetPath, targetName, targetName, KEY, targetName)
 
-	tesItemResource(t, config, configUpdate, rsPath)
+	testItemResource(t, rsPath, config, configUpdate)
 
 	deleteProducer(client, token)
 }

--- a/akeyless/resource_producer_test.go
+++ b/akeyless/resource_producer_test.go
@@ -99,9 +99,9 @@ func TestGithubProducerResource(t *testing.T) {
 	config := fmt.Sprintf(`
 		resource "akeyless_producer_github" "%v" {
 			name            		= "%v"
-			installation_id 		= "%v"
-			token_permissions 	   	= %v
-			github_app_id 		  	= %v
+			installation_id 		= %v
+			token_permissions 		= %v
+			github_app_id 			= %v
 			github_app_private_key	= "%v"
 		}
 	`, name, itemPath, GITHUB_INSTALL_ID, GITHUB_TOKEN_PERM, GITHUB_APP_ID, GITHUB_APP_KEY)

--- a/akeyless/resource_producer_test.go
+++ b/akeyless/resource_producer_test.go
@@ -10,22 +10,22 @@ import (
 )
 
 const (
-	GITHUB_INSTALL_ID   = 1234
-	GITHUB_INSTALL_REPO = "XXXXXXXX"
-	GITHUB_APP_ID       = 1234
-	GITHUB_APP_KEY      = "XXXXXXXX"
-	GITLAB_TOKEN        = "XXXXXXXX"
-	GCP_KEY             = "XXXXXXXX"
-	GCP_SA_EMAIL        = "XXXXXXXX"
-	GCP_TOKEN_SCOPES    = "XXXXXXXX"
-	KEY                 = "XXXXXXXX"
-	PRODUCER_NAME       = "terraform-tests/mysql_for_rs_test"
-	MYSQL_USERNAME      = "XXXXXXXX"
-	MYSQL_PASSWORD      = "XXXXXXXX"
-	MYSQL_HOST          = "127.0.0.1"
-	MYSQL_PORT          = "3306"
-	MYSQL_DBNAME        = "XXXXXXXX"
-	K8S_HOST            = "https://kubernetes.docker.internal:6443"
+	GITHUB_INSTALL_ORGANIZATION = "XXXXXXXX"
+	GITHUB_INSTALL_REPO         = "XXXXXXXX"
+	GITHUB_APP_ID               = 1234
+	GITHUB_APP_KEY              = "XXXXXXXX"
+	GITLAB_TOKEN                = "XXXXXXXX"
+	GCP_KEY                     = "XXXXXXXX"
+	GCP_SA_EMAIL                = "XXXXXXXX"
+	GCP_TOKEN_SCOPES            = "XXXXXXXX"
+	KEY                         = "XXXXXXXX"
+	PRODUCER_NAME               = "terraform-tests/mysql_for_rs_test"
+	MYSQL_USERNAME              = "XXXXXXXX"
+	MYSQL_PASSWORD              = "XXXXXXXX"
+	MYSQL_HOST                  = "127.0.0.1"
+	MYSQL_PORT                  = "3306"
+	MYSQL_DBNAME                = "XXXXXXXX"
+	K8S_HOST                    = "https://kubernetes.docker.internal:6443"
 )
 
 var (
@@ -97,13 +97,13 @@ func TestGithubProducerResource(t *testing.T) {
 	itemPath := testPath(name)
 	config := fmt.Sprintf(`
 		resource "akeyless_producer_github" "%v" {
-			name            		= "%v"
-			installation_id 		= %v
-			token_permissions 		= %v
-			github_app_id 			= %v
-			github_app_private_key 	= "%v"
+			name            		  = "%v"
+			installation_organization = "%v"
+			token_permissions 		  = %v
+			github_app_id 			  = %v
+			github_app_private_key 	  = "%v"
 		}
-	`, name, itemPath, GITHUB_INSTALL_ID, GITHUB_TOKEN_PERM, GITHUB_APP_ID, GITHUB_APP_KEY)
+	`, name, itemPath, GITHUB_INSTALL_ORGANIZATION, GITHUB_TOKEN_PERM, GITHUB_APP_ID, GITHUB_APP_KEY)
 
 	configUpdate := fmt.Sprintf(`
 		resource "akeyless_producer_github" "%v" {

--- a/akeyless/resource_static_secret_test.go
+++ b/akeyless/resource_static_secret_test.go
@@ -36,6 +36,7 @@ func TestStaticResource(t *testing.T) {
 			secure_access_url 			= "http://abc.com"
 			tags 						= ["t1", "t3"]
 			description 				= "bbbb"
+            keep_prev_version           = "true"
 		}
 	`, secretName, secretPath)
 

--- a/akeyless/resource_static_secret_test.go
+++ b/akeyless/resource_static_secret_test.go
@@ -19,11 +19,12 @@ func TestStaticResource(t *testing.T) {
 
 	config := fmt.Sprintf(`
 		resource "akeyless_static_secret" "%v" {
-			path 		= "%v"
-			value 		= "{\"secret value\":\"abc\"}"
-			format 		= "json"
-			tags 		= ["t1", "t2"]
-			description = "aaaa"
+			path 				= "%v"
+			value 				= "{\"secret value\":\"abc\"}"
+			format 				= "json"
+			tags 				= ["t1", "t2"]
+			description 		= "aaaa"
+            keep_prev_version	= "true"
 		}
 	`, secretName, secretPath)
 
@@ -36,7 +37,6 @@ func TestStaticResource(t *testing.T) {
 			secure_access_url 			= "http://abc.com"
 			tags 						= ["t1", "t3"]
 			description 				= "bbbb"
-            keep_prev_version           = "true"
 		}
 	`, secretName, secretPath)
 

--- a/akeyless/resource_tokenizer_test.go
+++ b/akeyless/resource_tokenizer_test.go
@@ -44,7 +44,7 @@ func TestTokenizerCreateUpdate(t *testing.T) {
 		}
 	`, name, itemPath)
 
-	tesItemResource(t, config, configUpdate, itemPath)
+	testItemResource(t, itemPath, config, configUpdate)
 }
 
 func TestTokenizerCustomType(t *testing.T) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,7 @@ output "auth_method" {
 - `email_login` (Block List) A configuration block, described below, that attempts to authenticate using email and password. (see [below for nested schema](#nestedblock--email_login))
 - `gcp_login` (Block List) A configuration block, described below, that attempts to authenticate using GCP-IAM authentication credentials. (see [below for nested schema](#nestedblock--gcp_login))
 - `jwt_login` (Block List) A configuration block, described below, that attempts to authenticate using JWT authentication.  The JWT can be provided as a command line variable or it will be pulled out of an environment variable named AKEYLESS_AUTH_JWT. (see [below for nested schema](#nestedblock--jwt_login))
+- `token_login` (Block List) A configuration block, described below, that attempts to authenticate using akeyless token. The token can be provided as a command line variable or it will be pulled out of an environment variable named AKEYLESS_AUTH_TOKEN. (see [below for nested schema](#nestedblock--token_login))
 - `uid_login` (Block List) A configuration block, described below, that attempts to authenticate using Universal Identity authentication. (see [below for nested schema](#nestedblock--uid_login))
 
 <a id="nestedblock--api_key_login"></a>
@@ -189,10 +190,21 @@ Required:
 - `jwt` (String, Sensitive)
 
 
+<a id="nestedblock--token_login"></a>
+### Nested Schema for `token_login`
+
+Required:
+
+- `token` (String, Sensitive)
+
+
 <a id="nestedblock--uid_login"></a>
 ### Nested Schema for `uid_login`
 
 Required:
 
-- `access_id` (String)
 - `uid_token` (String, Sensitive)
+
+Optional:
+
+- `access_id` (String)

--- a/docs/resources/auth_method_api_key.md
+++ b/docs/resources/auth_method_api_key.md
@@ -24,6 +24,7 @@ AWS API Key Auth Method Resource
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
 - `access_key` (String, Sensitive) Auth Method access key
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `force_sub_claims` (Boolean) enforce role-association must include sub claims
 - `jwt_ttl` (Number) Creds expiration time in minutes

--- a/docs/resources/auth_method_aws_iam.md
+++ b/docs/resources/auth_method_aws_iam.md
@@ -24,6 +24,7 @@ AWS IAM Auth Method Resource
 
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_arn` (Set of String) A list of full arns that the access is restricted to
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `bound_resource_id` (Set of String) A list of full resource ids that the access is restricted to

--- a/docs/resources/auth_method_azure_ad.md
+++ b/docs/resources/auth_method_azure_ad.md
@@ -25,6 +25,7 @@ Azure Active Directory Auth Method Resource
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
 - `audience` (String) The audience in the JWT
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_group_id` (Set of String) A list of group ids that the access is restricted to
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `bound_providers` (Set of String) A list of resource providers that the access is restricted to (e.g, Microsoft.Compute, Microsoft.ManagedIdentity, etc)

--- a/docs/resources/auth_method_cert.md
+++ b/docs/resources/auth_method_cert.md
@@ -24,6 +24,7 @@ Cert Auth Method Resource
 
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_common_names` (Set of String) A list of names. At least one must exist in the Common Name. Supports globbing.
 - `bound_dns_sans` (Set of String) A list of DNS names. At least one must exist in the SANs. Supports globbing.
 - `bound_email_sans` (Set of String) A list of Email Addresses. At least one must exist in the SANs. Supports globbing.

--- a/docs/resources/auth_method_gcp.md
+++ b/docs/resources/auth_method_gcp.md
@@ -25,6 +25,7 @@ GCE Auth Method Resource
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
 - `audience` (String) The audience to verify in the JWT received by the client
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `bound_labels` (Set of String) GCE only. A list of GCP labels formatted as key:value pairs that must be set on instances in order to authenticate. For multiple values repeat this flag.
 - `bound_projects` (Set of String) A list of GCP project IDs. Clients must belong to any of the provided projects in order to authenticate. For multiple values repeat this flag.

--- a/docs/resources/auth_method_k8s.md
+++ b/docs/resources/auth_method_k8s.md
@@ -24,6 +24,7 @@ Kubernetes Auth Method Resource
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
 - `audience` (String) The audience in the Kubernetes JWT that the access is restricted to
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `bound_namespaces` (Set of String) A list of namespaces that the access is restricted to
 - `bound_pod_names` (Set of String) A list of pod names that the access is restricted to

--- a/docs/resources/auth_method_oauth2.md
+++ b/docs/resources/auth_method_oauth2.md
@@ -25,6 +25,7 @@ AOAuth2 Auth Method Resource
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
 - `audience` (String) The audience in the JWT
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_client_ids` (Set of String) The clients ids that the access is restricted to
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `force_sub_claims` (Boolean) enforce role-association must include sub claims

--- a/docs/resources/auth_method_oidc.md
+++ b/docs/resources/auth_method_oidc.md
@@ -25,6 +25,7 @@ OIDC Auth Method Resource
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
 - `allowed_redirect_uri` (Set of String) Allowed redirect URIs after the authentication (default is https://console.akeyless.io/login-oidc to enable OIDC via Akeyless Console and  http://127.0.0.1:* to enable OIDC via akeyless CLI)
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `client_id` (String) Client ID
 - `client_secret` (String) Client Secret

--- a/docs/resources/auth_method_saml.md
+++ b/docs/resources/auth_method_saml.md
@@ -25,6 +25,7 @@ SAML Auth Method Resource
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
 - `allowed_redirect_uri` (Set of String) Allowed redirect URIs after the authentication (default is https://console.akeyless.io/login-saml to enable SAML via Akeyless Console and  http://127.0.0.1:* to enable SAML via akeyless CLI)
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `force_sub_claims` (Boolean) enforce role-association must include sub claims
 - `idp_metadata_url` (String) IDP metadata url

--- a/docs/resources/auth_method_universal_identity.md
+++ b/docs/resources/auth_method_universal_identity.md
@@ -23,6 +23,7 @@ Akeyless Universal Identity Auth Method Resource
 
 - `access_expires` (Number) Access expiration date in Unix timestamp (select 0 for access without expiry date)
 - `access_id` (String) Auth Method access ID
+- `audit_logs_claims` (Set of String) Subclaims to include in audit logs
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `deny_inheritance` (Boolean) Deny from root to create children
 - `deny_rotate` (Boolean) Deny from the token to rotate

--- a/docs/resources/dynamic_secret_github.md
+++ b/docs/resources/dynamic_secret_github.md
@@ -25,7 +25,8 @@ Github dynamic secret resource
 - `github_app_private_key` (String) Github application private key (base64 encoded key)
 - `github_base_url` (String) Github base url
 - `installation_id` (Number) Github application installation id
-- `installation_repository` (String) Optional, instead of installation id, set a GitHub repository '<owner>/<repo-name>'
+- `installation_organization` (String) Instead of installation id, set a GitHub organization name
+- `installation_repository` (String) Instead of installation id, set a GitHub repository '<owner>/<repo-name>'
 - `target_name` (String) Name of existing target to use in dynamic secret creation
 - `token_permissions` (Set of String) Tokens' allowed permissions. By default use installation allowed permissions. Input format: key=value pairs or JSON strings, e.g - -p contents=read -p issues=write or -p '{content:read}'
 - `token_repositories` (Set of String) Tokens' allowed repositories. By default use installation allowed repositories. To specify multiple repositories use argument multiple times: -r RepoName1 -r RepoName2

--- a/docs/resources/static_secret.md
+++ b/docs/resources/static_secret.md
@@ -47,6 +47,7 @@ resource "akeyless_static_secret" "secret" {
 
 - `description` (String) Description of the object
 - `format` (String) Secret format [text/json] (relevant only for type 'generic')
+- `keep_prev_version` (String) Whether to keep previous version [true/false]. If not set, use default according to account settings
 - `multiline_value` (Boolean) The provided value is a multiline value (separated by '
 ')
 - `protection_key` (String) The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
 # Use Semantic versioning only. Please update the version number before opening a pull request.
-v1.6.4
+v1.7.0


### PR DESCRIPTION
Changes:
- Update version
- Add audit_logs_claims to Auth methods resources
- Make access_id optional when using u-token for auth
- Add installation_organization (Organization Name) param to dynamic_secret_github resource
- Add keep_prev_version to static_secret resource

Manual tests:
- Created, updated and deleted auth with new audit_logs_claims param
- Created, updated and deleted universal identity auth without access_id
- Created, updated and deleted gitlab dynamic secret with installation_organization, including updating from/to mutual installation id/repository, and also combined.
- Created secret, updated value/description/both with/without keep_prev_version and checked version creation accordingly. Finally deleted.

All Changed tests in the code were run successfully.