### PR TITLE
Mark the key attribute of rotated secrets as computed

### DIFF
--- a/akeyless/resource_rotated_secret_aws.go
+++ b/akeyless/resource_rotated_secret_aws.go
@@ -90,6 +90,7 @@ func resourceRotatedSecretAws() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_azure.go
+++ b/akeyless/resource_rotated_secret_azure.go
@@ -100,6 +100,7 @@ func resourceRotatedSecretAzure() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_cassandra.go
+++ b/akeyless/resource_rotated_secret_cassandra.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretCassandra() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_custom.go
+++ b/akeyless/resource_rotated_secret_custom.go
@@ -68,6 +68,7 @@ func resourceRotatedSecretCustom() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_dockerhub.go
+++ b/akeyless/resource_rotated_secret_dockerhub.go
@@ -72,6 +72,7 @@ func resourceRotatedSecretDockerHub() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    false,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_gcp.go
+++ b/akeyless/resource_rotated_secret_gcp.go
@@ -89,6 +89,7 @@ func resourceRotatedSecretGcp() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_hanadb.go
+++ b/akeyless/resource_rotated_secret_hanadb.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretHanaDb() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_ldap.go
+++ b/akeyless/resource_rotated_secret_ldap.go
@@ -97,6 +97,7 @@ func resourceRotatedSecretLdap() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_mongo.go
+++ b/akeyless/resource_rotated_secret_mongo.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretMongo() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_mssql.go
+++ b/akeyless/resource_rotated_secret_mssql.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretMsSql() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_mysql.go
+++ b/akeyless/resource_rotated_secret_mysql.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretMySql() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_oracle.go
+++ b/akeyless/resource_rotated_secret_oracle.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretOracle() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_postgresql.go
+++ b/akeyless/resource_rotated_secret_postgresql.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretPostgreSql() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_redis.go
+++ b/akeyless/resource_rotated_secret_redis.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretRedis() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_redshift.go
+++ b/akeyless/resource_rotated_secret_redshift.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretRedshift() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_snowflake.go
+++ b/akeyless/resource_rotated_secret_snowflake.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretSnowflake() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_ssh.go
+++ b/akeyless/resource_rotated_secret_ssh.go
@@ -90,6 +90,7 @@ func resourceRotatedSecretSsh() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {

--- a/akeyless/resource_rotated_secret_windos.go
+++ b/akeyless/resource_rotated_secret_windos.go
@@ -85,6 +85,7 @@ func resourceRotatedSecretWindows() *schema.Resource {
 			"key": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of a key that is used to encrypt the secret value (if empty, the account default protectionKey key will be used)",
 			},
 			"tags": {


### PR DESCRIPTION
For a rotated secret with the `key` left as `null`, a plan after the initial apply will show a diff
```
      - key                        = "acc-axxxxxxxxxxm__account-def-secrets-key__" -> null
 ```

This marks the key attribute as computed in addition to optional to let Terraform know the value may be set by the practitioner, but if left unset the provider may set a value.