### PR TITLE
Use twine to publish to pypi instead of community action  

### DIFF
--- a/.github/actions/cdktf-python/action.yaml
+++ b/.github/actions/cdktf-python/action.yaml
@@ -15,23 +15,14 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry==1.4.2
-        pip install twine==6.0.1
 
-    - name: Build Python package
+    - name: Build and Publish Python package
       shell: bash
       run: |
         cd "${{ github.workspace }}/python/akeyless/.gen"
+        poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN_PASSWORD }}
         poetry build
-        cp -r ./ "${{ github.workspace }}/"
-
-    - name: Publish Python package
-      shell: bash
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_PASSWORD }}
-      run: |
-        cd "${{ github.workspace }}/python/akeyless/.gen"
-        python -m twine upload dist/*
+        poetry publish
 
     - name: Release CDKTF-Python summary
       shell: bash

--- a/.github/actions/cdktf-python/action.yaml
+++ b/.github/actions/cdktf-python/action.yaml
@@ -15,7 +15,7 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry==1.4.2
-        pip install twine
+        pip install twine==6.0.1
 
     - name: Build Python package
       shell: bash

--- a/.github/actions/cdktf-python/action.yaml
+++ b/.github/actions/cdktf-python/action.yaml
@@ -15,6 +15,7 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install poetry==1.4.2
+        pip install twine
 
     - name: Build Python package
       shell: bash
@@ -24,7 +25,16 @@ runs:
         cp -r ./ "${{ github.workspace }}/"
 
     - name: Publish Python package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      shell: bash
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_PASSWORD }}
+      run: |
+        cd "${{ github.workspace }}/python/akeyless/.gen"
+        python -m twine upload dist/*
+        
+#    - name: Publish Python package
+#      uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Release CDKTF-Python summary
       shell: bash

--- a/.github/actions/cdktf-python/action.yaml
+++ b/.github/actions/cdktf-python/action.yaml
@@ -32,9 +32,6 @@ runs:
       run: |
         cd "${{ github.workspace }}/python/akeyless/.gen"
         python -m twine upload dist/*
-        
-#    - name: Publish Python package
-#      uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: Release CDKTF-Python summary
       shell: bash

--- a/.github/workflows/release_cdktf.yaml
+++ b/.github/workflows/release_cdktf.yaml
@@ -7,11 +7,6 @@ on:
 jobs:
   release-cdktf:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    permissions:
-      id-token: write
-    environment:
-      name: pypi
-      url: https://pypi.org/p/akeyless-cdktf/
     runs-on: ubuntu-22.04
     strategy:
       matrix:


### PR DESCRIPTION
Use twine to publish to pypi instead of the community action: gh-action-pypi-publish