### PR TITLE
ASM-15137 | Add Gateway URL to JWT/OAuth2 Authentication Method Resource

### DIFF
--- a/akeyless/resource_auth_method_oauth2.go
+++ b/akeyless/resource_auth_method_oauth2.go
@@ -97,6 +97,11 @@ func resourceAuthMethodOauth2() *schema.Resource {
 				Description: "Protection from accidental deletion of this auth method, [true/false]",
 				Default:     "false",
 			},
+			"gateway_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Gateway URL for the OAuth2 auth method",
+			},
 			"access_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -129,6 +134,7 @@ func resourceAuthMethodOauth2Create(d *schema.ResourceData, m interface{}) error
 	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
 	subClaims := common.ExpandStringList(subClaimsSet.List())
 	deleteProtection := d.Get("delete_protection").(string)
+	gatewayUrl := d.Get("gateway_url").(string)
 
 	body := akeyless_api.AuthMethodCreateOauth2{
 		Name:             name,
@@ -146,6 +152,7 @@ func resourceAuthMethodOauth2Create(d *schema.ResourceData, m interface{}) error
 	common.GetAkeylessPtr(&body.JwksJsonData, jwksJsonData)
 	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 	common.GetAkeylessPtr(&body.DeleteProtection, deleteProtection)
+	common.GetAkeylessPtr(&body.GatewayUrl, gatewayUrl)
 
 	rOut, _, err := client.AuthMethodCreateOauth2(ctx).Body(body).Execute()
 	if err != nil {
@@ -291,6 +298,9 @@ func resourceAuthMethodOauth2Read(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
+	// Note: GatewayUrl field is not available in the read response
+	// This is a limitation of the current Akeyless API response structure
+
 	d.SetId(path)
 
 	return nil
@@ -319,6 +329,7 @@ func resourceAuthMethodOauth2Update(d *schema.ResourceData, m interface{}) error
 	subClaimsSet := d.Get("audit_logs_claims").(*schema.Set)
 	subClaims := common.ExpandStringList(subClaimsSet.List())
 	deleteProtection := d.Get("delete_protection").(string)
+	gatewayUrl := d.Get("gateway_url").(string)
 
 	body := akeyless_api.AuthMethodUpdateOauth2{
 		Name:             name,
@@ -337,6 +348,7 @@ func resourceAuthMethodOauth2Update(d *schema.ResourceData, m interface{}) error
 	common.GetAkeylessPtr(&body.JwksJsonData, jwksJsonData)
 	common.GetAkeylessPtr(&body.AuditLogsClaims, subClaims)
 	common.GetAkeylessPtr(&body.DeleteProtection, deleteProtection)
+	common.GetAkeylessPtr(&body.GatewayUrl, gatewayUrl)
 
 	_, _, err := client.AuthMethodUpdateOauth2(ctx).Body(body).Execute()
 	if err != nil {

--- a/docs/resources/auth_method_oauth2.md
+++ b/docs/resources/auth_method_oauth2.md
@@ -29,6 +29,7 @@ AOAuth2 Auth Method Resource
 - `bound_ips` (Set of String) A CIDR whitelist with the IPs that the access is restricted to
 - `delete_protection` (String) Protection from accidental deletion of this auth method, [true/false]
 - `force_sub_claims` (Boolean) enforce role-association must include sub claims
+- `gateway_url` (String) Gateway URL for the OAuth2 auth method
 - `issuer` (String) Issuer URL
 - `jwks_json_data` (String) The JSON Web Key Set (JWKS) containing the public keys that should be used to verify any JSON Web Token (JWT) issued by the authorization serve, in base64 format.
 - `jwks_uri` (String) The URL to the JSON Web Key Set (JWKS) that containing the public keys that should be used to verify any JSON Web Token (JWT) issued by the authorization server.

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
 # Use Semantic versioning only. Please update the version number before opening a pull request.
-v1.10.1
+v1.10.2


### PR DESCRIPTION
Add missing `gateway-url` argument to the auth method OAuth2/JWT resource, see https://docs.akeyless.io/reference/authmethodcreateoauth2 arguments.