### PR TITLE
ASM-15100 | Add Secret Value Filter to Rotated Secret Sync

### DIFF
--- a/akeyless/common/utils.go
+++ b/akeyless/common/utils.go
@@ -238,24 +238,24 @@ func GetTargetType(itemTargetsAssoc []akeyless_api.ItemTargetAssociation) string
 	return itemTargetsAssoc[0].GetTargetType()
 }
 
-func GetRotatorUscSync(associatedItems []akeyless_api.ItemUSCSyncAssociation, uscName, remoteSecretName string) (namespace string, exists bool) {
+func GetRotatorUscSync(associatedItems []akeyless_api.ItemUSCSyncAssociation, uscName, remoteSecretName string) (namespace, filterSecretValue string, exists bool) {
 	for _, assoc := range associatedItems {
 		if assoc.ItemName == nil || *assoc.ItemName != uscName {
 			continue
 		}
 
 		if assoc.Attributes == nil {
-			return "", false
+			return "", "", false
 		}
 		attr := *assoc.Attributes
 
 		if attr.SecretName == nil || *attr.SecretName != remoteSecretName {
-			return "", false
+			return "", "", false
 		}
 
-		return attr.GetNamespace(), true
+		return attr.GetNamespace(), attr.GetJqSecretFilter(), true
 	}
-	return "", false
+	return "", "", false
 }
 
 func GetTagsForUpdate(d *schema.ResourceData, name, token string, newTags []string,

--- a/akeyless/resource_rotated_secret_sync.go
+++ b/akeyless/resource_rotated_secret_sync.go
@@ -45,6 +45,11 @@ func resourceRotatedSecretSync() *schema.Resource {
 				Optional:    true,
 				Description: "Vault namespace, releavnt only for Hashicorp Vault Target",
 			},
+			"filter_secret_value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "JQ expression to filter or transform the secret value",
+			},
 		},
 	}
 }
@@ -60,14 +65,17 @@ func resourceRotatedSecretSyncCreate(d *schema.ResourceData, m any) error {
 	uscName := d.Get("usc_name").(string)
 	remoteSecretName := d.Get("remote_secret_name").(string)
 	namespace := d.Get("namespace").(string)
+	filterSecretValue := d.Get("filter_secret_value").(string)
 
 	body := akeyless_api.RotatedSecretSync{
-		Name:  rsName,
-		Token: &token,
+		Name:              rsName,
+		Token:             &token,
+		FilterSecretValue: &filterSecretValue,
 	}
 	common.GetAkeylessPtr(&body.UscName, uscName)
 	common.GetAkeylessPtr(&body.RemoteSecretName, remoteSecretName)
 	common.GetAkeylessPtr(&body.Namespace, namespace)
+	common.GetAkeylessPtr(&body.FilterSecretValue, filterSecretValue)
 
 	_, resp, err := client.RotatedSecretSync(ctx).Body(body).Execute()
 	if err != nil {

--- a/akeyless/resource_rotated_secret_sync.go
+++ b/akeyless/resource_rotated_secret_sync.go
@@ -110,11 +110,15 @@ func resourceRotatedSecretSyncRead(d *schema.ResourceData, m any) error {
 	}
 
 	if rOut.UscSyncAssociatedItems != nil {
-		namespace, exists := common.GetRotatorUscSync(rOut.UscSyncAssociatedItems, uscName, remoteSecretName)
+		namespace, filterSecretValue, exists := common.GetRotatorUscSync(rOut.UscSyncAssociatedItems, uscName, remoteSecretName)
 		if !exists {
 			return fmt.Errorf("rotated secret sync not found for rotated secret name: %s, usc name: %s, remote secret name: %s", rsName, uscName, remoteSecretName)
 		}
-		err := d.Set("namespace", namespace)
+		err = d.Set("namespace", namespace)
+		if err != nil {
+			return err
+		}
+		err = d.Set("filter_secret_value", filterSecretValue)
 		if err != nil {
 			return err
 		}
@@ -180,11 +184,15 @@ func resourceRotatedSecretSyncImport(d *schema.ResourceData, m any) ([]*schema.R
 	}
 
 	if rOut.UscSyncAssociatedItems != nil {
-		namespace, exists := common.GetRotatorUscSync(rOut.UscSyncAssociatedItems, uscName, remoteSecretName)
+		namespace, filterSecretValue, exists := common.GetRotatorUscSync(rOut.UscSyncAssociatedItems, uscName, remoteSecretName)
 		if !exists {
 			return nil, fmt.Errorf("rotated secret sync not found for rotated secret name: %s, usc name: %s, remote secret name: %s", rsName, uscName, remoteSecretName)
 		}
 		err := d.Set("namespace", namespace)
+		if err != nil {
+			return nil, err
+		}
+		err = d.Set("filter_secret_value", filterSecretValue)
 		if err != nil {
 			return nil, err
 		}

--- a/akeyless/resource_rotated_secret_sync.go
+++ b/akeyless/resource_rotated_secret_sync.go
@@ -68,9 +68,8 @@ func resourceRotatedSecretSyncCreate(d *schema.ResourceData, m any) error {
 	filterSecretValue := d.Get("filter_secret_value").(string)
 
 	body := akeyless_api.RotatedSecretSync{
-		Name:              rsName,
-		Token:             &token,
-		FilterSecretValue: &filterSecretValue,
+		Name:  rsName,
+		Token: &token,
 	}
 	common.GetAkeylessPtr(&body.UscName, uscName)
 	common.GetAkeylessPtr(&body.RemoteSecretName, remoteSecretName)

--- a/docs/resources/rotated_secret_sync.md
+++ b/docs/resources/rotated_secret_sync.md
@@ -20,6 +20,7 @@ Sync Rotated Secret with Universal Secrets Connector resource
 - `name` (String) Rotated Secret name
 - `remote_secret_name` (String) Remote Secret Name that will be synced on the remote endpoint
 - `usc_name` (String) Universal Secret Connector name
+- `filter_secret_value` (String) JQ expression to filter or transform the secret value
 
 ### Optional
 

--- a/docs/resources/rotated_secret_sync.md
+++ b/docs/resources/rotated_secret_sync.md
@@ -20,10 +20,10 @@ Sync Rotated Secret with Universal Secrets Connector resource
 - `name` (String) Rotated Secret name
 - `remote_secret_name` (String) Remote Secret Name that will be synced on the remote endpoint
 - `usc_name` (String) Universal Secret Connector name
-- `filter_secret_value` (String) JQ expression to filter or transform the secret value
 
 ### Optional
 
+- `filter_secret_value` (String) JQ expression to filter or transform the secret value
 - `namespace` (String) Vault namespace, releavnt only for Hashicorp Vault Target
 
 ### Read-Only

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
 # Use Semantic versioning only. Please update the version number before opening a pull request.
-v1.10.3
+v1.10.4


### PR DESCRIPTION
Add missing `filter_secret_value` argument to `akeyless_rotated_secret_sync` resource, see https://docs.akeyless.io/reference/rotatedsecretsync.

