### PR TITLE
fix: remove hardcoded 127.0.0.1 defaults from database host fields

### DIFF
--- a/akeyless/resource_dynamic_secret_mssql.go
+++ b/akeyless/resource_dynamic_secret_mssql.go
@@ -53,7 +53,6 @@ func resourceDynamicSecretMssql() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "MS SQL Server host name",
-				Default:     "127.0.0.1",
 			},
 			"mssql_port": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_dynamic_secret_mysql.go
+++ b/akeyless/resource_dynamic_secret_mysql.go
@@ -54,7 +54,6 @@ func resourceDynamicSecretMysql() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "MySQL host name",
-				Default:     "127.0.0.1",
 			},
 			"mysql_port": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_dynamic_secret_oracle.go
+++ b/akeyless/resource_dynamic_secret_oracle.go
@@ -53,7 +53,6 @@ func resourceDynamicSecretOracle() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Oracle host name",
-				Default:     "127.0.0.1",
 			},
 			"oracle_port": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_dynamic_secret_postgresql.go
+++ b/akeyless/resource_dynamic_secret_postgresql.go
@@ -52,7 +52,6 @@ func resourceDynamicSecretPostgresql() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "PostgreSQL host name",
-				Default:     "127.0.0.1",
 			},
 			"postgresql_port": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_dynamic_secret_redshift.go
+++ b/akeyless/resource_dynamic_secret_redshift.go
@@ -53,7 +53,6 @@ func resourceDynamicSecretRedshift() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Redshift host name",
-				Default:     "127.0.0.1",
 			},
 			"redshift_port": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_gateway_producer_mssql.go
+++ b/akeyless/resource_gateway_producer_mssql.go
@@ -59,7 +59,6 @@ func resourceProducerMssql() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				Description: "MS SQL Server host name",
-				Default:     "127.0.0.1",
 			},
 			"mssql_port": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_gateway_producer_mysql.go
+++ b/akeyless/resource_gateway_producer_mysql.go
@@ -60,7 +60,6 @@ func resourceProducerMysql() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				Description: "MySQL host name",
-				Default:     "127.0.0.1",
 			},
 			"mysql_port": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_gateway_producer_oracle.go
+++ b/akeyless/resource_gateway_producer_oracle.go
@@ -59,7 +59,6 @@ func resourceProducerOracle() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				Description: "Oracle host name",
-				Default:     "127.0.0.1",
 			},
 			"oracle_port": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_gateway_producer_postgresql.go
+++ b/akeyless/resource_gateway_producer_postgresql.go
@@ -58,7 +58,6 @@ func resourceProducerPostgresql() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				Description: "PostgreSQL host name",
-				Default:     "127.0.0.1",
 			},
 			"postgresql_port": {
 				Type:        schema.TypeString,

--- a/akeyless/resource_gateway_producer_redshift.go
+++ b/akeyless/resource_gateway_producer_redshift.go
@@ -59,7 +59,6 @@ func resourceProducerRedshift() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				Description: "Redshift host name",
-				Default:     "127.0.0.1",
 			},
 			"redshift_port": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
Remove hardcoded Default: '127.0.0.1' values from database host configuration fields across all database dynamic secret and gateway producer resources.

This change prevents accidental connections to localhost in production environments by requiring users to explicitly specify the database host.

Changes:
- Dynamic Secret Resources: MySQL, MSSQL, PostgreSQL, Oracle, Redshift
- Gateway Producer Resources: MySQL, MSSQL, PostgreSQL, Oracle, Redshift

Breaking Change: Users who relied on the implicit localhost default will need to explicitly set host fields (mysql_host, postgresql_host, etc.)

Fixes: Database host defaulting to 127.0.0.1 when creating dynamic credentials