### PR TITLE
ASM-16216 | `ForceNew` on `associate_role_auth_method` `role_name`/`am_name`

### DIFF
--- a/akeyless/resource_assoc_role_am.go
+++ b/akeyless/resource_assoc_role_am.go
@@ -27,14 +27,18 @@ func resourceAssocRoleAm() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"role_name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The role to associate",
+				Type:             schema.TypeString,
+				Required:         true,
+				Description:      "The role to associate",
+				ForceNew:         true,
+				DiffSuppressFunc: common.DiffSuppressOnLeadingSlash,
 			},
 			"am_name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The auth method to associate",
+				Type:             schema.TypeString,
+				Required:         true,
+				Description:      "The auth method to associate",
+				ForceNew:         true,
+				DiffSuppressFunc: common.DiffSuppressOnLeadingSlash,
 			},
 			"sub_claims": {
 				Type:        schema.TypeMap,
@@ -148,16 +152,12 @@ func resourceAssocRoleAmRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceAssocRoleAmUpdate(d *schema.ResourceData, m interface{}) error {
 
-	err := validateAssocRoleAmUpdateParams(d)
-	if err != nil {
-		return fmt.Errorf("can't update association: %v", err)
-	}
-
 	provider := m.(*providerMeta)
 	client := *provider.client
 	token := *provider.token
 
 	ctx := context.Background()
+
 	subClaims := d.Get("sub_claims").(map[string]interface{})
 	sc := make(map[string]string, len(subClaims))
 	for k, v := range subClaims {
@@ -359,13 +359,4 @@ func getAssocImportParams(d *schema.ResourceData) (*AssocParams, error) {
 func isAssocId(s string) bool {
 	// e.g. ass-abcdef123456fedcba
 	return strings.HasPrefix(s, "ass-") && len(s) == 24
-}
-
-// every resource_associate_role_auth_method can relate to exactly 1 assoc.
-// updating its role_name or am_name meaning destroy and re-create the resource.
-// therefore only sub_claims and case_sensitive are able to update.
-// if you wish to update role_name or am_name, destroy the resource first.
-func validateAssocRoleAmUpdateParams(d *schema.ResourceData) error {
-	paramsMustNotUpdate := []string{"role_name", "am_name"}
-	return common.GetErrorOnUpdateParam(d, paramsMustNotUpdate)
 }

--- a/akeyless/tests/no_gateway/resource_role_test.go
+++ b/akeyless/tests/no_gateway/resource_role_test.go
@@ -664,6 +664,105 @@ func TestRoleResourceAndAssocAuthMethod(t *testing.T) {
 	})
 }
 
+// TestAssocRoleAmForceNewOnRoleNameChange verifies that changing role_name
+// (ForceNew) destroys and recreates the association, including when one role
+// path has a leading slash and the other does not.
+func TestAssocRoleAmForceNewOnRoleNameChange(t *testing.T) {
+	authMethodPath := testPath("test_am_assoc_force_new")
+	role1Path := "/" + testPath("test_role1_with_slash")
+	role2Path := testPath("test_role2_no_slash")
+
+	testutils.DeleteRole(role1Path)
+	testutils.DeleteRole(role2Path)
+	testutils.DeleteAuthMethod(authMethodPath, "api_key")
+	defer testutils.DeleteRole(role1Path)
+	defer testutils.DeleteRole(role2Path)
+	defer testutils.DeleteAuthMethod(authMethodPath, "api_key")
+
+	configForRole := func(assocRolePath string) string {
+		return fmt.Sprintf(`
+		resource "akeyless_auth_method_api_key" "am" {
+			name = "%v"
+		}
+		resource "akeyless_role" "role1" {
+			name = "%v"
+			rules {
+				capability = ["read"]
+				path       = "%v"
+				rule_type  = "item-rule"
+			}
+		}
+		resource "akeyless_role" "role2" {
+			name = "%v"
+			rules {
+				capability = ["read"]
+				path       = "%v"
+				rule_type  = "item-rule"
+			}
+		}
+		resource "akeyless_associate_role_auth_method" "assoc" {
+			am_name   = akeyless_auth_method_api_key.am.name
+			role_name = "%v"
+			sub_claims = {
+				"groups" = "admins"
+			}
+			depends_on = [
+				akeyless_auth_method_api_key.am,
+				akeyless_role.role1,
+				akeyless_role.role2,
+			]
+		}
+	`, authMethodPath, role1Path, RULE_PATH, role2Path, RULE_PATH, assocRolePath)
+	}
+
+	var assocIDAfterRole1 string
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configForRole(role1Path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("akeyless_associate_role_auth_method.assoc", "role_name", role1Path),
+					testutils.CheckAssocExistsOnRole(t, role1Path, authMethodPath),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["akeyless_associate_role_auth_method.assoc"]
+						if !ok {
+							return fmt.Errorf("assoc resource not found in state")
+						}
+						assocIDAfterRole1 = rs.Primary.ID
+						if assocIDAfterRole1 == "" {
+							return fmt.Errorf("assoc id is empty after create")
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config: configForRole(role2Path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("akeyless_associate_role_auth_method.assoc", "role_name", role2Path),
+					testutils.CheckAssocExistsOnRole(t, role2Path, authMethodPath),
+					testutils.CheckAssocAbsentOnRole(t, role1Path),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["akeyless_associate_role_auth_method.assoc"]
+						if !ok {
+							return fmt.Errorf("assoc resource not found in state")
+						}
+						if rs.Primary.ID == "" {
+							return fmt.Errorf("assoc id is empty after recreate")
+						}
+						if rs.Primary.ID == assocIDAfterRole1 {
+							return fmt.Errorf("expected destroy+create (new assoc id), got same id %s", assocIDAfterRole1)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func TestRoleResourceWithFewAssocs(t *testing.T) {
 	resourceName := "test_role_few_assocs"
 	rolePath := testPath(resourceName)

--- a/akeyless/tests/testutils/testutils.go
+++ b/akeyless/tests/testutils/testutils.go
@@ -1101,6 +1101,66 @@ func CheckAssocExistsRemotely2(t *testing.T, roleName, authMethodPath string) re
 	}
 }
 
+func pathEqualIgnoreLeadingSlash(a, b string) bool {
+	return common.EnsureLeadingSlash(a) == common.EnsureLeadingSlash(b)
+}
+
+// CheckAssocExistsOnRole asserts the role has exactly one auth-method association
+// whose auth method name matches authMethodPath (leading-slash insensitive).
+func CheckAssocExistsOnRole(t *testing.T, roleName, authMethodPath string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, token, err := GetClient()
+		if err != nil {
+			return err
+		}
+
+		res, _, err := client.GetRole(context.Background()).Body(akeyless_api.GetRole{
+			Name:  roleName,
+			Token: &token,
+		}).Execute()
+		if err != nil {
+			return fmt.Errorf("get role %q: %w", roleName, err)
+		}
+
+		assocs := res.GetRoleAuthMethodsAssoc()
+		if len(assocs) != 1 {
+			return fmt.Errorf("role %q: expected 1 assoc, got %d", roleName, len(assocs))
+		}
+		amName := ""
+		if assocs[0].AuthMethodName != nil {
+			amName = *assocs[0].AuthMethodName
+		}
+		if !pathEqualIgnoreLeadingSlash(amName, authMethodPath) {
+			return fmt.Errorf("role %q: assoc am_name %q != %q", roleName, amName, authMethodPath)
+		}
+		return nil
+	}
+}
+
+// CheckAssocAbsentOnRole asserts the role has no auth-method associations.
+func CheckAssocAbsentOnRole(t *testing.T, roleName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, token, err := GetClient()
+		if err != nil {
+			return err
+		}
+
+		res, _, err := client.GetRole(context.Background()).Body(akeyless_api.GetRole{
+			Name:  roleName,
+			Token: &token,
+		}).Execute()
+		if err != nil {
+			return fmt.Errorf("get role %q: %w", roleName, err)
+		}
+
+		assocs := res.GetRoleAuthMethodsAssoc()
+		if len(assocs) != 0 {
+			return fmt.Errorf("role %q: expected 0 assocs after recreate, got %d", roleName, len(assocs))
+		}
+		return nil
+	}
+}
+
 func CheckAddRoleRemotely(t *testing.T, roleName string, rulesNum int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client, token, err := GetClient()

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
 # Use Semantic versioning only. Please update the version number before opening a pull request.
-v2.0.3
+v2.0.4


### PR DESCRIPTION
## Summary
- Fix ASM-16216: renaming a role with an `akeyless_associate_role_auth_method` no longer fails with `update of "role_name" is not allowed`.
- Set `ForceNew` + `DiffSuppressOnLeadingSlash` on `role_name` / `am_name` so Terraform replaces the association (destroy + create) instead of attempting an unsupported in-place update.
- Remove `validateAssocRoleAmUpdateParams` (redundant with `ForceNew`).
- Bump version to `v2.0.4`.

## Test plan
- [x] Local provider build `2.0.4-rc1` (`local/akeyless-community/akeyless`)
- [x] Manual repro (role rename):
  - Initial apply created assoc `ass-irucke090iv7v0da6oac` on `/inv/ASM-16216/role`
  - Plan after rename showed `must be replaced` / `# forces replacement` on assoc + role (not in-place update)
  - Apply order: destroy assoc → destroy role → create role → create assoc
  - After apply: new assoc `ass-rgzqehf1qa58k80pvve9` on `/inv/ASM-16216/role-renamed`
- [x] Added ACC test `TestAssocRoleAmForceNewOnRoleNameChange` (auth method + 2 roles with/without leading `/`, switch assoc role_name, assert new assoc id + remote presence/absence)
